### PR TITLE
Support alternate outputPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ The following options are available for the Faro JavaScript bundler plugins:
 - `apiKey: string` *required*: The API key for your Faro Collector, you can generate a new scope on [grafana.com], refer to the [Obtaining API key](#obtaining-api-key) section
 - `appId: string` *required*: The ID of your application, it should match the `appId` value used in your Faro Web SDK configuration
 - `stackId: string` *required*: The ID of the stack, found in Frontend Observability under **Settings** and **Web SDK Config**
+- `outputPath: string` *optional*: Folder where output files will be located
 - `outputFiles: string[]` *optional*: An array of source map files to upload, by default Faro uploads all source maps
 - `bundleId: string` *optional*: The ID of the bundle/build, by default auto-generated, or specify an ID to filter by bundle ID in Frontend Observability
 - `keepSourcemaps: boolean` *optional*: Whether to keep the source maps in your generated bundle after uploading, default `false`

--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -10,6 +10,7 @@ export interface FaroSourceMapUploaderPluginOptions {
   appId: string;
   apiKey: string;
   stackId: string;
+  outputPath?: string;
   outputFiles?: string[];
   bundleId?: string;
   keepSourcemaps?: boolean;

--- a/packages/faro-webpack/src/index.ts
+++ b/packages/faro-webpack/src/index.ts
@@ -26,6 +26,7 @@ export default class FaroSourceMapUploaderPlugin
   private stackId: string;
   private endpoint: string;
   private bundleId: string;
+  private outputPathOverride?: string;
   private outputFiles?: string[];
   private keepSourcemaps?: boolean;
   private gzipContents?: boolean;
@@ -36,6 +37,7 @@ export default class FaroSourceMapUploaderPlugin
     this.apiKey = options.apiKey;
     this.stackId = options.stackId;
     this.endpoint = `${options.endpoint}/app/${options.appId}/sourcemaps/`;
+    this.outputPathOverride = options.outputPath;
     this.outputFiles = options.outputFiles;
     this.bundleId = options.bundleId ?? String(Date.now() + randomString(5));
     this.keepSourcemaps = options.keepSourcemaps;
@@ -49,7 +51,7 @@ export default class FaroSourceMapUploaderPlugin
    */
   apply(compiler: webpack.Compiler): void {
     const BannerPlugin = compiler.webpack.BannerPlugin;
-    const outputPath = compiler.options.output.path;
+    const outputPath = this.outputPathOverride ?? compiler.options.output.path;
 
     compiler.options.plugins = compiler.options.plugins || [];
     compiler.options.plugins.push(


### PR DESCRIPTION
When using certain Webpack configurations, particularly the one used by Create-React-App, compiled JS files and their associated mappings are not stored in the base `build` folder. Instead, they're stored in a nested `build/static/js` folder. As the `readdirSync` function used by the Webpack plugin is not recursive, this means the JS files will not be found using the default folder. This PR adds the ability to set the outputPath in the plugin configuration.

I did not touch the Rollup plugin, as I do not use that system and am not familiar enough with it to make changes or even know if it needs the same change.