### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,14 +11,3 @@ updates:
       interval: 'daily'
     target-branch: 'main'
     open-pull-requests-limit: 10
-
-  - package-ecosystem: 'npm'
-    directory: '/' 
-    schedule:
-      interval: 'daily' 
-    target-branch: 'main'
-    open-pull-requests-limit: 10
-    allow:
-      - dependency-type: "direct"
-        update-types: ["security"]
-

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/' 
+    schedule:
+      interval: 'monthly'
+    target-branch: 'main'
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: 'npm'
+    directory: '/' 
+    schedule:
+      interval: 'weekly' 
+    target-branch: 'main'
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: "direct"
+        update-types: ["security"]
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/' 
     schedule:
-      interval: 'monthly'
+      interval: 'daily'
     target-branch: 'main'
     open-pull-requests-limit: 10
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/' 
     schedule:
-      interval: 'weekly' 
+      interval: 'daily' 
     target-branch: 'main'
     open-pull-requests-limit: 10
     allow:


### PR DESCRIPTION
# Why

Enable Dependabot checks.

# What
- Monthly check for standard updates
- Weekly check for security updates