### PR TITLE
Add log message if verbose and no sourcemaps were uploaded

### DIFF
--- a/packages/faro-webpack/src/index.ts
+++ b/packages/faro-webpack/src/index.ts
@@ -172,9 +172,11 @@ export default class FaroSourceMapUploaderPlugin
         console.error(e);
       }
 
-      if (uploadedSourcemaps.length && this.verbose) {
+      if (this.verbose) {
         consoleInfoOrange(
-          `Uploaded sourcemaps: ${uploadedSourcemaps.map(map => map.split('/').pop()).join(", ")}`
+          uploadedSourcemaps.length
+            ? `Uploaded sourcemaps: ${uploadedSourcemaps.map(map => map.split('/').pop()).join(", ")}`
+            : `No sourcemaps uploaded`
         );
       }
     });


### PR DESCRIPTION
While debugging why sourcemaps are not getting uploaded, it's useful to know if no sourcemaps were uploaded.  This change adds that log.