### PR TITLE
feat: add inject-bundle-id command to CLI

### DIFF
--- a/packages/faro-cli/README.md
+++ b/packages/faro-cli/README.md
@@ -91,6 +91,55 @@ npx faro-cli upload \
   --verbose
 ```
 
+### Injecting Bundle ID into JavaScript Files
+
+For applications that don't use Webpack or Rollup, or in cases where you need to add the bundle ID to already built JavaScript files, you can use the `inject-bundle-id` command:
+
+```bash
+npx faro-cli inject-bundle-id \
+  --bundle-id "your-bundle-id" \
+  --app-name "your-app-name" \
+  --files "dist/**/*.js" \
+  --verbose
+```
+
+This command will:
+1. Locate all JavaScript files matching the specified glob patterns
+2. Check if each file already has a bundle ID snippet
+3. Prepend the bundle ID snippet to files that don't have it
+4. Export the bundle ID to an environment variable for potential later use with other commands
+
+#### Options
+
+- `--bundle-id, -b`: The bundle ID to inject (leave blank to generate a random ID)
+- `--app-name, -n`: Application name used in the bundle ID snippet
+- `--files, -f`: File patterns to match (multiple patterns can be specified)
+- `--verbose, -v`: Enable verbose logging
+- `--dry-run, -d`: Only print which files would be modified without making changes
+
+#### Examples
+
+Generate a random bundle ID and inject it into all JS files:
+
+```bash
+npx faro-cli inject-bundle-id \
+  --bundle-id generate \
+  --app-name "my-app" \
+  --files "dist/**/*.js" \
+  --verbose
+```
+
+Do a dry run first to see which files would be modified:
+
+```bash
+npx faro-cli inject-bundle-id \
+  --bundle-id "your-bundle-id" \
+  --app-name "my-app" \
+  --files "dist/**/*.js" \
+  --dry-run \
+  --verbose
+```
+
 ### Using with Bundler Plugins
 
 When using with the Faro bundler plugins, you can set the `skipUpload` option to `true` in the plugin configuration to skip uploading source maps during the build process and instead use the CLI to upload them later.

--- a/packages/faro-cli/package.json
+++ b/packages/faro-cli/package.json
@@ -23,12 +23,14 @@
   "dependencies": {
     "@grafana/faro-bundlers-shared": "^0.3.0",
     "commander": "^13.1.0",
+    "glob": "^10.3.10",
     "jest": "^29.7.0",
     "tar": "^7.1.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@rollup/plugin-typescript": "^11.1.5",
+    "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.10.5",
     "@types/tar": "^6.1.13",

--- a/packages/faro-cli/src/test/bundleId.test.ts
+++ b/packages/faro-cli/src/test/bundleId.test.ts
@@ -1,0 +1,94 @@
+import fs from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { injectBundleId } from '../index';
+import { faroBundleIdSnippet } from '@grafana/faro-bundlers-shared';
+
+describe('injectBundleId', () => {
+  const tempDir = path.join(tmpdir(), 'faro-cli-test-');
+  let testDir: string;
+  let testFiles: string[] = [];
+
+  beforeEach(async () => {
+    // Create a temporary directory for test files
+    testDir = fs.mkdtempSync(tempDir);
+
+    // Create test files
+    const jsContent = 'console.log("Hello, world!");';
+    const alreadyInjectedContent = faroBundleIdSnippet('existing-id', 'testapp') + jsContent;
+
+    const file1 = path.join(testDir, 'test1.js');
+    const file2 = path.join(testDir, 'test2.js');
+    const file3 = path.join(testDir, 'already-injected.js');
+
+    fs.writeFileSync(file1, jsContent);
+    fs.writeFileSync(file2, jsContent);
+    fs.writeFileSync(file3, alreadyInjectedContent);
+
+    testFiles = [file1, file2, file3];
+  });
+
+  afterEach(() => {
+    // Clean up test files
+    testFiles.forEach((file) => {
+      if (fs.existsSync(file)) {
+        fs.unlinkSync(file);
+      }
+    });
+
+    // Remove test directory
+    if (fs.existsSync(testDir)) {
+      fs.rmdirSync(testDir);
+    }
+  });
+
+  it('injects bundle ID into JavaScript files', async () => {
+    const bundleId = 'test-bundle-id';
+    const appName = 'testapp';
+    const results = await injectBundleId(bundleId, appName, [testFiles[0], testFiles[1]]);
+
+    // Verify both files were modified
+    expect(results.length).toBe(2);
+    expect(results[0].modified).toBe(true);
+    expect(results[1].modified).toBe(true);
+
+    // Verify content was modified correctly
+    const content1 = fs.readFileSync(testFiles[0], 'utf8');
+    const content2 = fs.readFileSync(testFiles[1], 'utf8');
+
+    const expectedSnippet = faroBundleIdSnippet(bundleId, appName);
+    expect(content1.startsWith(expectedSnippet)).toBe(true);
+    expect(content2.startsWith(expectedSnippet)).toBe(true);
+  });
+
+  it('skips files that already have the bundle ID injected', async () => {
+    const bundleId = 'new-bundle-id';
+    const appName = 'testapp';
+    const results = await injectBundleId(bundleId, appName, [testFiles[2]]);
+
+    // Verify the file was not modified
+    expect(results.length).toBe(1);
+    expect(results[0].modified).toBe(false);
+
+    // Verify content was not changed
+    const content = fs.readFileSync(testFiles[2]).toString();
+    expect(content).toContain('existing-id');
+    expect(content).not.toContain(bundleId);
+  });
+
+  it('respects dry run mode', async () => {
+    const bundleId = 'dry-run-test-id';
+    const appName = 'testapp';
+    const originalContent = fs.readFileSync(testFiles[0]).toString();
+
+    const results = await injectBundleId(bundleId, appName, [testFiles[0]], { dryRun: true });
+
+    // Verify result indicates modification would happen
+    expect(results.length).toBe(1);
+    expect(results[0].modified).toBe(true);
+
+    // Verify file was not actually modified
+    const afterContent = fs.readFileSync(testFiles[0]).toString();
+    expect(afterContent).toBe(originalContent);
+  });
+});

--- a/packages/faro-cli/src/test/index.test.ts
+++ b/packages/faro-cli/src/test/index.test.ts
@@ -92,6 +92,18 @@ describe('faro-cli', () => {
     console.warn = originalConsoleWarn;
   });
 
+  afterAll(() => {
+    jest.resetAllMocks();
+
+    jest.unmock('fs');
+    jest.unmock('path');
+    jest.unmock('tar');
+    jest.unmock('child_process');
+    jest.unmock('zlib');
+    jest.unmock('os');
+    jest.unmock('@grafana/faro-bundlers-shared');
+  });
+
   describe('uploadSourceMap', () => {
     const mockOptions: UploadSourceMapOptions = {
       endpoint: mockEndpoint,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2044,6 +2044,14 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
+"@types/glob@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz#b63e70155391b0584dce44e7ea25190bbc38f2fc"
+  integrity sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==
+  dependencies:
+    "@types/minimatch" "^5.1.2"
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.9"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
@@ -2087,6 +2095,11 @@
   version "3.0.5"
   resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz#1001cc5e6a3704b83c236027e77f2f58ea010f40"
   integrity sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==
+
+"@types/minimatch@^5.1.2":
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
+  integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/minimist@^1.2.0":
   version "1.2.5"
@@ -4301,7 +4314,6 @@ inquirer@^8.2.4:
 
 ip@^2.0.0, "ip@https://registry.npmjs.org/neoip/-/neoip-2.1.0.tgz":
   version "2.1.0"
-  uid "66c8fb429ef007c341902261641e906b046cf594"
   resolved "https://registry.npmjs.org/neoip/-/neoip-2.1.0.tgz#66c8fb429ef007c341902261641e906b046cf594"
 
 irregular-plurals@^3.2.0:


### PR DESCRIPTION
For applications that don't use Webpack or Rollup, or in cases where you need to add the bundle ID to already built JavaScript files, you can use the `inject-bundle-id` command:

```bash
npx faro-cli inject-bundle-id \
  --bundle-id "your-bundle-id" \
  --app-name "your-app-name" \
  --files "dist/**/*.js" \
  --verbose
```

This command will:
1. Locate all JavaScript files matching the specified glob patterns
2. Check if each file already has a bundle ID snippet
3. Prepend the bundle ID snippet to files that don't have it
4. Export the bundle ID to an environment variable for potential later use with other commands