### PR TITLE
fix(deps): remove jest from faro-cli dependencies

### DIFF
--- a/packages/faro-cli/package.json
+++ b/packages/faro-cli/package.json
@@ -25,7 +25,6 @@
     "commander": "^13.1.0",
     "dotenv": "^17.0.1",
     "glob": "^10.3.10",
-    "jest": "^29.7.0",
     "tar": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`jest` is currently being unintentionally installed as a transitive dependency when installing `@grafana/faro-cli`. This pull request aims to resolve that. Noting that it is already listed as a dev dependency.