### PR TITLE
refactor: improve findMapFiles function 

### DIFF
--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -547,16 +547,24 @@ cat ${filePath} | gzip -c | curl -X POST ${proxyArg} ${proxyUserArg} "${sourcema
  */
 export const findMapFiles = (dir: string, recursive: boolean = false): string[] => {
   const sourcemapFiles: string[] = [];
-  const files = fs.readdirSync(dir, { recursive });
 
-  for (const file of files) {
-    const filePath = path.join(dir, file.toString());
-    const stat = fs.statSync(filePath);
+  const walk = (currentDir: string) => {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
 
-    if (stat.isFile() && file.toString().endsWith('.map')) {
-      sourcemapFiles.push(filePath);
+    for (const entry of entries) {
+      const entryPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        if (recursive) {
+          walk(entryPath);
+        }
+      } else if (entry.isFile() && entry.name.endsWith('.map')) {
+        sourcemapFiles.push(entryPath);
+      }
     }
-  }
+  };
+
+  walk(dir);
 
   return sourcemapFiles;
 };


### PR DESCRIPTION
to use recursive directory traversal

recursive option for readdirSync was added in NodeJS 20.1.0 and 18.17.0 meaning the option doesn't work in projects with older NodeJS version
<img width="632" height="191" alt="image" src="https://github.com/user-attachments/assets/c91bd6c6-ef9c-4ea1-8819-de66462ff0c3" />
