### PR TITLE
feat: add prefixPathBasenameOnly option

### DIFF
--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -23,6 +23,7 @@ export interface FaroSourceMapUploaderPluginOptions {
   recursive?: boolean; // Whether to recursively search subdirectories for sourcemaps
   proxy?: string; // Proxy URL to use for source map uploads (e.g., "http://proxy.example.com:8080" or "http://user:pass@proxy.example.com:8080")
   prefixPath?: string; // Prefix to prepend to the file property in source maps (e.g., "_next/" or "robo/assets/")
+  prefixPathBasenameOnly?: boolean; // When true, strips the directory path from the file property before prepending prefixPath (useful for flat CDN uploads)
 }
 
 interface UploadSourceMapOptions {
@@ -345,7 +346,8 @@ export const ensureSourceMapFileProperty = (
 export const modifySourceMapFileProperty = (
   filePath: string,
   prefix: string,
-  verbose?: boolean
+  verbose?: boolean,
+  basenameOnly?: boolean
 ): void => {
   try {
     // ensure file property exists before modifying
@@ -356,7 +358,8 @@ export const modifySourceMapFileProperty = (
     const sourceMap = JSON.parse(sourceMapContent);
 
     if (sourceMap.file && !sourceMap.file.startsWith(normalizedPrefix)) {
-      sourceMap.file = `${normalizedPrefix}${sourceMap.file}`;
+      const fileValue = basenameOnly ? path.basename(sourceMap.file) : sourceMap.file;
+      sourceMap.file = `${normalizedPrefix}${fileValue}`;
       fs.writeFileSync(filePath, JSON.stringify(sourceMap, null, 2));
       verbose &&
         consoleInfoOrange(

--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -342,6 +342,7 @@ export const ensureSourceMapFileProperty = (
  * @param filePath Path to the source map file
  * @param prefix Prefix to prepend to the file property (will be normalized)
  * @param verbose Whether to log verbose messages
+ * @param basenameOnly Whether to only use the basename of the file
  */
 export const modifySourceMapFileProperty = (
   filePath: string,

--- a/packages/faro-bundlers-shared/src/test/index.test.ts
+++ b/packages/faro-bundlers-shared/src/test/index.test.ts
@@ -180,6 +180,50 @@ describe('Bundlers Shared Utilities', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
   });
 
+  test('modifySourceMapFileProperty strips directory path when prefixPathBasenameOnly is true', () => {
+    const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'test-temp-'));
+    const sourceMapPath = path.join(tempDir, 'index-DWRl9wIG.js.map');
+
+    const sourceMap = {
+      version: 3,
+      file: 'assets/index-DWRl9wIG.js',
+      sources: ['index.ts'],
+      mappings: 'AAAA',
+    };
+
+    fs.writeFileSync(sourceMapPath, JSON.stringify(sourceMap, null, 2));
+
+    modifySourceMapFileProperty(sourceMapPath, 'https://cdn.example.com/assets/', false, true);
+
+    const modifiedSourceMap = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
+    expect(modifiedSourceMap.file).toBe('https://cdn.example.com/assets/index-DWRl9wIG.js');
+
+    // cleanup
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('modifySourceMapFileProperty preserves directory path when prefixPathBasenameOnly is false', () => {
+    const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'test-temp-'));
+    const sourceMapPath = path.join(tempDir, 'index-DWRl9wIG.js.map');
+
+    const sourceMap = {
+      version: 3,
+      file: 'assets/index-DWRl9wIG.js',
+      sources: ['index.ts'],
+      mappings: 'AAAA',
+    };
+
+    fs.writeFileSync(sourceMapPath, JSON.stringify(sourceMap, null, 2));
+
+    modifySourceMapFileProperty(sourceMapPath, 'https://cdn.example.com/robo/', false, false);
+
+    const modifiedSourceMap = JSON.parse(fs.readFileSync(sourceMapPath, 'utf8'));
+    expect(modifiedSourceMap.file).toBe('https://cdn.example.com/robo/assets/index-DWRl9wIG.js');
+
+    // cleanup
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
   test('ensureSourceMapFileProperty adds file property when missing', () => {
     const tempDir = fs.mkdtempSync(path.join(process.cwd(), 'test-temp-'));
     const sourceMapPath = path.join(tempDir, 'bundle.js.map');

--- a/packages/faro-esbuild/src/index.ts
+++ b/packages/faro-esbuild/src/index.ts
@@ -35,6 +35,7 @@ export default function faroEsbuildPlugin(
     recursive,
     proxy,
     prefixPath,
+    prefixPathBasenameOnly,
   } = pluginOptions;
   const bundleId =
     pluginOptions.bundleId ?? String(Date.now() + randomString(5));
@@ -137,7 +138,7 @@ export default function faroEsbuildPlugin(
               }
 
               if (fs.existsSync(file)) {
-                modifySourceMapFileProperty(file, prefixPath, verbose);
+                modifySourceMapFileProperty(file, prefixPath, verbose, prefixPathBasenameOnly);
               }
             }
           } catch (e) {

--- a/packages/faro-rollup/src/index.ts
+++ b/packages/faro-rollup/src/index.ts
@@ -33,6 +33,7 @@ export default function faroUploader(
     skipUpload,
     proxy,
     prefixPath,
+    prefixPathBasenameOnly,
   } = pluginOptions;
   const bundleId =
     pluginOptions.bundleId ?? String(Date.now() + randomString(5));
@@ -92,7 +93,7 @@ export default function faroUploader(
             }
             const filePath = path.join(outputPath, filenameStr);
             if (fs.existsSync(filePath)) {
-              modifySourceMapFileProperty(filePath, prefixPath, verbose);
+              modifySourceMapFileProperty(filePath, prefixPath, verbose, prefixPathBasenameOnly);
             }
           }
         } catch (e) {

--- a/packages/faro-webpack/src/index.ts
+++ b/packages/faro-webpack/src/index.ts
@@ -32,7 +32,8 @@ interface BannerPluginOptions {
 function modifySourceMapAssets(
   compilation: webpack.Compilation,
   prefix: string,
-  verbose?: boolean
+  verbose?: boolean,
+  basenameOnly?: boolean
 ): void {
   const normalizedPrefix = normalizePrefix(prefix);
 
@@ -48,7 +49,8 @@ function modifySourceMapAssets(
         }
 
         if (sourceMap.file && !sourceMap.file.startsWith(normalizedPrefix)) {
-          sourceMap.file = `${normalizedPrefix}${sourceMap.file}`;
+          const fileValue = basenameOnly ? path.basename(sourceMap.file) : sourceMap.file;
+          sourceMap.file = `${normalizedPrefix}${fileValue}`;
 
           compilation.updateAsset(
             filename,
@@ -93,6 +95,7 @@ export default class FaroSourceMapUploaderPlugin
   private nextjs?: boolean;
   private proxy?: string;
   private prefixPath?: string;
+  private prefixPathBasenameOnly?: boolean;
 
   constructor(options: WebpackFaroSourceMapUploaderPluginOptions) {
     this.appName = options.appName;
@@ -109,6 +112,7 @@ export default class FaroSourceMapUploaderPlugin
     this.skipUpload = options.skipUpload;
     this.nextjs = options.nextjs;
     this.prefixPath = options.prefixPath;
+    this.prefixPathBasenameOnly = options.prefixPathBasenameOnly;
     this.maxUploadSize =
       options.maxUploadSize && options.maxUploadSize > 0
         ? options.maxUploadSize
@@ -160,7 +164,7 @@ export default class FaroSourceMapUploaderPlugin
             stage: webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
           },
           () => {
-            modifySourceMapAssets(compilation, finalPrefix, this.verbose);
+            modifySourceMapAssets(compilation, finalPrefix, this.verbose, this.prefixPathBasenameOnly);
           }
         );
       });

--- a/packages/faro-webpack/src/index.ts
+++ b/packages/faro-webpack/src/index.ts
@@ -28,6 +28,7 @@ interface BannerPluginOptions {
  * @param compilation The webpack compilation object
  * @param prefix The prefix to prepend (will be normalized)
  * @param verbose Whether to log verbose messages
+ * @param basenameOnly Whether to only use the basename of the file
  */
 function modifySourceMapAssets(
   compilation: webpack.Compilation,

--- a/packages/faro-webpack/src/test/index.test.ts
+++ b/packages/faro-webpack/src/test/index.test.ts
@@ -417,6 +417,57 @@ describe("Faro Webpack Plugin", () => {
     expect(sourceMapJson.file).toBe("robo/assets/main.js");
   });
 
+  test("prefixPathBasenameOnly strips directory from file property before prepending prefix", async () => {
+    const testOutputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "webpack-prefixpath-basename-test-")
+    );
+
+    const { outputDir } = await runWebpack(
+      {
+        bundleId: "prefixpath-basename-test",
+        skipUpload: false,
+        keepSourcemaps: true,
+        outputPath: testOutputDir,
+        prefixPath: "robo/assets",
+        prefixPathBasenameOnly: true,
+      },
+      testOutputDir,
+      {
+        devtool: "source-map",
+      }
+    );
+
+    // nested/vendor.js.map has file: "nested/vendor.js" — with basenameOnly the directory should be stripped
+    const sourceMap = await fs.readFile(path.join(outputDir, "nested/vendor.js.map"), "utf8");
+    const sourceMapJson = JSON.parse(sourceMap);
+    expect(sourceMapJson.file).toBe("robo/assets/vendor.js");
+  });
+
+  test("without prefixPathBasenameOnly the directory is preserved in the file property", async () => {
+    const testOutputDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "webpack-prefixpath-no-basename-test-")
+    );
+
+    const { outputDir } = await runWebpack(
+      {
+        bundleId: "prefixpath-no-basename-test",
+        skipUpload: false,
+        keepSourcemaps: true,
+        outputPath: testOutputDir,
+        prefixPath: "robo/assets",
+        prefixPathBasenameOnly: false,
+      },
+      testOutputDir,
+      {
+        devtool: "source-map",
+      }
+    );
+
+    const sourceMap = await fs.readFile(path.join(outputDir, "nested/vendor.js.map"), "utf8");
+    const sourceMapJson = JSON.parse(sourceMap);
+    expect(sourceMapJson.file).toBe("robo/assets/nested/vendor.js");
+  });
+
   test("proxy option with authentication is passed correctly", async () => {
     const mockProxyUrl = "http://user:pass@proxy.example.com:8080";
 


### PR DESCRIPTION
adding the `prefixPathBasenameOnly` option, which strips the folder path from the bundle's assets when adding the prefixPath to a bundler config