### PR TITLE
fix: add files field to all packages to ensure dist is included in npm publish

### DIFF
--- a/packages/faro-bundlers-shared/package.json
+++ b/packages/faro-bundlers-shared/package.json
@@ -22,6 +22,12 @@
     "ansis": "^4.0.0",
     "tar": "^7.1.0"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/faro-cli/package.json
+++ b/packages/faro-cli/package.json
@@ -37,6 +37,12 @@
     "jest": "30.3.0",
     "ts-jest": "29.4.9"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/faro-esbuild/package.json
+++ b/packages/faro-esbuild/package.json
@@ -21,6 +21,12 @@
     "cross-fetch": "^4.0.0",
     "esbuild": "^0.28.0"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/faro-rollup/package.json
+++ b/packages/faro-rollup/package.json
@@ -22,6 +22,12 @@
     "magic-string": "^0.30.5",
     "rollup": "^4.22.4"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/packages/faro-webpack/package.json
+++ b/packages/faro-webpack/package.json
@@ -31,6 +31,12 @@
   "resolutions": {
     "axios": "^1.7.4"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
## Summary

- Adds a `files` field to all five package `package.json` files explicitly listing `dist`, `README.md`, `CHANGELOG.md`, and `LICENSE`
- Without this field, npm falls back to `.gitignore` rules when determining what to pack, and the root `.gitignore` excludes `dist/` — meaning built artifacts may not be included in the published tarball
- This was the root cause of `@grafana/faro-esbuild-plugin@0.4.1` being published without a `dist/` directory, making it unimportable
