### PR TITLE
fix(faro-esbuild-plugin): remove experimental warning from README

### DIFF
--- a/packages/faro-esbuild/README.md
+++ b/packages/faro-esbuild/README.md
@@ -1,8 +1,5 @@
 # Faro source map upload plugin - esbuild
 
-> [!WARNING]
-> This package is currently **experimental**. While it provides feature parity with the rollup and webpack plugins, it may have issues or limitations. Please report any problems you encounter.
-
 This plugin uploads source maps to the Faro collector to enable de-obfuscation of stack traces in the Grafana Cloud Frontend Observability UI.
 
 > [!NOTE]


### PR DESCRIPTION
## Summary

- Removes the experimental warning banner from the esbuild plugin README — the package has shipped multiple stable versions with full feature parity with the rollup and webpack plugins

## Context

This also serves as the trigger commit to get release-please to bump `@grafana/faro-esbuild-plugin` to `0.4.2`. The previous `files` field fix (#513) was absorbed into the last release before release-please could bump the esbuild version, so `0.4.1` was published to npm without a `dist/` directory. Merging this will cause release-please to propose `0.4.2` for esbuild only.