### PR TITLE
chore: dropping node 20.x, adding node 26.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20.x, 22.x, 24.x, 25.x]
+        node: [22.x, 24.x, 25.x, 26.x]
     steps:
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98


### PR DESCRIPTION
# what

node 20.x EOL is april 30th 2026, dropping node 20.x and adding 26.x support 