### PR TITLE
feat: add faro metro plugin support for react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,14 @@ A collection of plugins for various JavaScript bundlers. Used in conjunction wit
 
 ## Get started
 
-The Faro JavaScript bundler plugins work with the [Faro Web SDK](https://github.com/grafana/faro-web-sdk) and [Grafana Cloud Frontend Observability](https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/). To use these bundler plugins, you must first have instrumented your JavaScript application with Faro and be sending your telemetry data to a Faro Collector endpoint in Grafana Cloud. Follow the Frontend Observability [quickstart guide](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/quickstart/javascript/) to get started.
+The Faro JavaScript bundler plugins work with the [Faro Web SDK](https://github.com/grafana/faro-web-sdk), the [Faro React Native SDK](https://github.com/grafana/faro-react-native-sdk), and [Grafana Cloud Frontend Observability](https://grafana.com/products/cloud/frontend-observability-for-real-user-monitoring/). To use these bundler plugins, you must first have instrumented your JavaScript or React Native application with Faro and be sending your telemetry data to a Faro Collector endpoint in Grafana Cloud. Follow the Frontend Observability [quickstart guide](https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/quickstart/javascript/) to get started.
 
 After you have an instrumented JavaScript application sending data to Grafana Cloud, you are ready to get started.
 
 > [!NOTE]
 > The Faro JavaScript bundler plugins work with client-side rendered applications. Server-side rendering isn't yet supported.
+>
+> For **React Native**, use the Metro plugin below with [@grafana/faro-react-native](https://github.com/grafana/faro-react-native-sdk).
 
 ---
 
@@ -51,6 +53,24 @@ To install the Rollup/Vite plugin with `yarn`, run:
 ```bash
 yarn add --dev @grafana/faro-rollup-plugin
 ```
+
+### Metro (React Native)
+
+Use this plugin with **Metro** to inject a Faro bundle id into release bundles, emit Hermes-compatible source maps where applicable, and upload maps to Grafana Cloud (same auth model as the other plugins).
+
+To install the Metro plugin with `npm`, run:
+
+```bash
+npm install --save-dev @grafana/faro-metro-plugin
+```
+
+To install the Metro plugin with `yarn`, run:
+
+```bash
+yarn add --dev @grafana/faro-metro-plugin
+```
+
+For environment variables (`FARO_SOURCEMAP_API_KEY`, `FARO_BUNDLE_ID`, optional `FARO_SKIP_SOURCEMAP_UPLOAD`), iOS vs Android bundle filenames, and Hermes `sourceMapFile` alignment with `releaseBundleFilename`, see the [Metro plugin README](packages/faro-metro-plugin/README.md).
 
 ## Obtaining API key
 
@@ -125,6 +145,35 @@ export default defineConfig(({ mode }) => {
 });
 ```
 
+### Metro (React Native)
+
+To use the Metro plugin, wrap your config in `metro.config.js` (typically with `@react-native/metro-config`). Uploads are skipped for development builds unless you override `skipUpload`.
+
+```javascript
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const withFaroConfig = require('@grafana/faro-metro-plugin').default;
+
+module.exports = mergeConfig(
+  getDefaultConfig(__dirname),
+  withFaroConfig(
+    {},
+    {
+      appName: '$your-app-name',
+      // this URL is different from the Faro Collector URL - find this value in the Frontend Observability plugin under "Settings" -> "Source Maps" tab
+      endpoint: '$your-faro-sourcemap-api-url',
+      apiKey: process.env.FARO_SOURCEMAP_API_KEY,
+      appId: '$your-app-id',
+      stackId: '$your-stack-id',
+      bundleId: process.env.FARO_BUNDLE_ID,
+      gzipContents: true,
+      verbose: false,
+    }
+  )
+);
+```
+
+See the [Metro plugin README](packages/faro-metro-plugin/README.md) for CLI sanity checks (`react-native bundle`) and optional `sourceMapFile`.
+
 ### Configuration Options
 
 The following options are available for the Faro JavaScript bundler plugins:
@@ -173,6 +222,8 @@ yarn add --dev @grafana/faro-cli
 
 When using with the Faro bundler plugins, you can set the `skipUpload` option to `true` in the plugin configuration to skip uploading source maps during the build process and instead use the CLI to upload them later.
 
+**Web (Webpack / Vite / Rollup / Rspack):**
+
 ```bash
 npx faro-cli upload \
   --endpoint "https://faro-collector-prod-us-east-0.grafana.net" \
@@ -181,6 +232,19 @@ npx faro-cli upload \
   --stack-id "your-stack-id" \
   --bundle-id "your-bundle-id" \
   --output-path "./dist" \
+  --verbose
+```
+
+**React Native (Metro):** pass one `.map` with `--map` (your Gradle/Xcode hook or CI supplies the path). `--bundle-id` must match the id `@grafana/faro-metro-plugin` baked into the shipped bundle.
+
+```bash
+npx faro-cli metro upload \
+  --map "path/to/your.map" \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id   "$FARO_SOURCEMAP_APP_ID" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --api-key  "$FARO_SOURCEMAP_API_KEY" \
+  --bundle-id "$FARO_BUNDLE_ID" \
   --verbose
 ```
 

--- a/packages/faro-bundlers-shared/CHANGELOG.md
+++ b/packages/faro-bundlers-shared/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* `shouldProcessFile` / `JS_SOURCEMAP_PATTERN`: accept React Native Android/iOS bundle maps (`*.bundle.map`, `*.jsbundle.map`) so Metro uploads are not silently skipped when `sourceMapFile` uses names like `index.android.bundle`.
+
 ## [0.10.1](https://github.com/grafana/faro-javascript-bundler-plugins/compare/faro-bundlers-shared-v0.10.0...faro-bundlers-shared-v0.10.1) (2026-05-14)
 
 

--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -25,18 +25,6 @@ export interface FaroSourceMapUploaderPluginOptions {
   prefixPathBasenameOnly?: boolean; // When true, strips the directory path from the file property before prepending prefixPath (useful for flat CDN uploads)
 }
 
-/**
- * True for common env flag values: "1", "true" (case-insensitive, whitespace-trimmed).
- * Used for example with `FARO_SKIP_SOURCEMAP_UPLOAD`.
- */
-export function isTruthyEnvVar(value: string | undefined): boolean {
-  if (value == null) {
-    return false;
-  }
-  const normalized = value.trim().toLowerCase();
-  return normalized === "1" || normalized === "true";
-}
-
 interface UploadSourceMapOptions {
   sourcemapEndpoint: string;
   apiKey: string;

--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -25,6 +25,18 @@ export interface FaroSourceMapUploaderPluginOptions {
   prefixPathBasenameOnly?: boolean; // When true, strips the directory path from the file property before prepending prefixPath (useful for flat CDN uploads)
 }
 
+/**
+ * True for common env flag values: "1", "true" (case-insensitive, whitespace-trimmed).
+ * Used for example with `FARO_SKIP_SOURCEMAP_UPLOAD`.
+ */
+export function isTruthyEnvVar(value: string | undefined): boolean {
+  if (value == null) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true";
+}
+
 interface UploadSourceMapOptions {
   sourcemapEndpoint: string;
   apiKey: string;
@@ -300,8 +312,13 @@ const includedInOutputFiles = (filename: string, outputFiles: string[] | undefin
   return false;
 }
 
+/**
+ * Prepend to JS bundles so `getBundleId(appName)` in `@grafana/faro-core` can read `meta.app.bundleId`.
+ * Must resolve the **same** global as `globalObject` in faro-core (`globalThis` first). A previous
+ * `window`-first order broke React Native Hermes when `window` exists but is not `globalThis`.
+ */
 export const faroBundleIdSnippet = (bundleId: string, appName: string) => {
-  return `(function(){try{var g=typeof window!=="undefined"?window:typeof global!=="undefined"?global:typeof self!=="undefined"?self:{};g["__faroBundleId_${appName}"]="${bundleId}"}catch(l){}})();`;
+  return `(function(){try{var g=typeof globalThis!=="undefined"?globalThis:typeof global!=="undefined"?global:typeof window!=="undefined"?window:typeof self!=="undefined"?self:{};g["__faroBundleId_${appName}"]="${bundleId}"}catch(l){}})();`;
 };
 
 export function randomString(length?: number): string {
@@ -317,7 +334,9 @@ export const ESBUILD_PLUGIN_NAME = "faro-esbuild-plugin";
 
 export const THIRTY_MB_IN_BYTES = 30 * 1024 * 1024;
 
-export const JS_SOURCEMAP_PATTERN = /\.(js|ts|jsx|tsx|mjs|cjs)\.map$/;
+/** JS (and React Native bundle) source maps — excludes e.g. CSS maps. */
+export const JS_SOURCEMAP_PATTERN =
+  /\.(js|ts|jsx|tsx|mjs|cjs)\.map$|\.(bundle|jsbundle)\.map$/;
 
 export const cleanAppName = (appName: string) => {
   return appName.toUpperCase().replace(/[^A-Z0-9]/g, '_');

--- a/packages/faro-bundlers-shared/src/test/index.test.ts
+++ b/packages/faro-bundlers-shared/src/test/index.test.ts
@@ -64,6 +64,8 @@ describe('Bundlers Shared Utilities', () => {
     expect(shouldProcessFile('main.tsx.map', undefined)).toBeTruthy();
     expect(shouldProcessFile('module.mjs.map', undefined)).toBeTruthy();
     expect(shouldProcessFile('lib.cjs.map', undefined)).toBeTruthy();
+    expect(shouldProcessFile('index.android.bundle.map', undefined)).toBeTruthy();
+    expect(shouldProcessFile('main.jsbundle.map', undefined)).toBeTruthy();
 
     // Non-sourcemap files
     expect(shouldProcessFile('styles.css.map', undefined)).toBeFalsy();

--- a/packages/faro-cli/README.md
+++ b/packages/faro-cli/README.md
@@ -22,7 +22,9 @@ yarn add --dev @grafana/faro-cli
 
 ### Uploading Source Maps
 
-The CLI uses cURL under the hood to upload source maps to the Faro API:
+The CLI uses cURL under the hood to upload source maps to the Faro API.
+
+**Web (Webpack / Vite / Rollup / Rspack):**
 
 ```bash
 npx faro-cli upload \
@@ -35,7 +37,25 @@ npx faro-cli upload \
   --verbose
 ```
 
-The CLI will automatically find and upload all `.map` files in the specified output directory and its subdirectories. It recursively searches through all folders to find any source map files, so you don't need to specify patterns or worry about nested directory structures.
+**React Native (Metro):**
+
+```bash
+npx faro-cli metro upload \
+  --map "path/to/your.map" \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id   "$FARO_SOURCEMAP_APP_ID" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --api-key  "$FARO_SOURCEMAP_API_KEY" \
+  --bundle-id "$FARO_BUNDLE_ID" \
+  --verbose
+```
+
+The two commands differ only in **how they discover the map(s) to upload**:
+
+- `upload` (web) takes a directory via `--output-path` and recursively scans it for every `.map` file. You don't enumerate paths or worry about nested folders.
+- `metro upload` (React Native) takes one `.map` path via `--map`. The CLI never derives this path itself — the caller (Gradle hook, Xcode post-build script, manual invocation) is responsible for pointing at the right file. `--bundle-id` (or `FARO_BUNDLE_ID`) must match whatever id `@grafana/faro-metro-plugin` baked into the shipped JS bundle so the uploaded map keys onto Faro's runtime telemetry. See the [`@grafana/faro-metro-plugin` README](../faro-metro-plugin/README.md) for which map to pass on which platform.
+
+Both commands do the same lightweight pre-flight on each `.map` before uploading: parse it as JSON, verify it is a v3 source map, and (for compatibility with downstream symbolication) write back the `file` property if it is missing. They never touch the `mappings`, `sources`, or `sourcesContent` fields. See [Connection settings precedence](#connection-settings-precedence) and [Validation and exit codes](#validation-and-exit-codes) for the full contract.
 
 #### File Size Limits
 
@@ -91,6 +111,8 @@ npx faro-cli upload \
   --verbose
 ```
 
+For `metro upload`, gzipping is **on by default** (the `.map` is POSTed as a gzipped tarball). Pass `--no-gzip` to POST the raw `.map` JSON instead — useful when debugging an upload against a proxy that mangles `Content-Encoding`.
+
 #### Using a Proxy
 
 If you need to route requests through a proxy server, you can use the `--proxy` option:
@@ -108,7 +130,7 @@ npx faro-cli upload \
   --verbose
 ```
 
-The proxy URL will be passed to cURL using the `--proxy` parameter. If your proxy requires authentication, you can use the `--proxy-user` option (or `-U`) to provide credentials in the format `username:password`.
+The proxy URL will be passed to cURL using the `--proxy` parameter. If your proxy requires authentication, you can use the `--proxy-user` option (or `-U`) to provide credentials in the format `username:password`. The same `--proxy` and `--proxy-user` flags work identically on `metro upload`.
 
 ### Injecting Bundle ID into JavaScript Files
 
@@ -157,6 +179,8 @@ npx faro-cli inject-bundle-id \
   --dry-run \
   --verbose
 ```
+
+> **Web only.** This command is for already-built JavaScript bundles produced by web bundlers that don't already integrate the Faro plugin. The React Native (Metro) flow injects the bundle id at Metro time via `@grafana/faro-metro-plugin`'s preamble, so you don't run `inject-bundle-id` on RN bundles.
 
 ### Using with Bundler Plugins
 
@@ -225,9 +249,48 @@ module.exports = {
 };
 ```
 
+#### Metro Example (React Native)
+
+`@grafana/faro-metro-plugin` is the equivalent of the Webpack/Rollup plugins for React Native. It supports the same `skipUpload` option, with the same meaning: when `true`, the plugin won't upload it.
+
+```js
+// metro.config.js
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const withFaroConfig = require('@grafana/faro-metro-plugin').default;
+
+const faroOpts = {
+  appName: 'MyApp',
+  endpoint: 'https://faro-api-prod-us-east-0.grafana.net/faro/api/v1',
+  appId: 'your-app-id',
+  stackId: 'your-stack-id',
+  apiKey: process.env.FARO_SOURCEMAP_API_KEY,
+  bundleId: process.env.FARO_BUNDLE_ID,
+  verbose: true,
+};
+
+module.exports = mergeConfig(
+  getDefaultConfig(__dirname),
+  withFaroConfig({}, faroOpts),
+);
+```
+
+Manual invocation has the same shape on every platform:
+
+```bash
+npx faro-cli metro upload \
+  --map "path/to/your.map" \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id   "$FARO_SOURCEMAP_APP_ID" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --api-key  "$FARO_SOURCEMAP_API_KEY" \
+  --bundle-id "$FARO_BUNDLE_ID"
+```
+
+Each connection setting (and `--bundle-id`) also accepts the matching `FARO_*` env var as a fallback if the flag is omitted, so a step that already exports the full `FARO_*` set can call `faro-cli metro upload --map …` and nothing else.
+
 ### Generating a curl Command
 
-If you prefer to use curl directly, you can generate a curl command:
+If you prefer to use curl directly, you can generate a curl command. Web example:
 
 ```bash
 npx faro-cli curl \
@@ -237,6 +300,18 @@ npx faro-cli curl \
   --stack-id "your-stack-id" \
   --bundle-id "your-bundle-id" \
   --file "./dist/main.js.map"
+```
+
+React Native (Metro) — same `curl` subcommand, just point `--file` at the `.map` you want to upload and pass the bundle id that matches your shipped JS:
+
+```bash
+npx faro-cli curl \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id   "$FARO_SOURCEMAP_APP_ID" \
+  --api-key  "$FARO_SOURCEMAP_API_KEY" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --bundle-id "$FARO_BUNDLE_ID" \
+  --file     "path/to/your.map"
 ```
 
 You can also generate a curl command that uses gzip compression:
@@ -301,6 +376,50 @@ This will output a curl command that you can copy and run manually.
 - `-z, --gzip-payload`: Generate a command that gzips the payload (default: false)
 - `-x, --proxy <url>`: Proxy URL to use for cURL requests (optional)
 - `-U, --proxy-user <user:password>`: Username and password for proxy authentication (optional)
+
+### Metro Upload Command (`metro upload`)
+
+- `--map <path>` (required): Path to the `.map` file to upload. The CLI does
+  not derive or autodetect this path — the caller picks the file.
+- `-e, --endpoint <url>`: Faro source map API base URL. Falls back to
+  `FARO_SOURCEMAP_ENDPOINT`.
+- `-a, --app-id <id>`: Faro app id. Falls back to `FARO_SOURCEMAP_APP_ID`.
+- `-s, --stack-id <id>`: Grafana Cloud stack id. Falls back to
+  `FARO_SOURCEMAP_STACK_ID`.
+- `-k, --api-key <key>`: Bearer API key. Falls back to
+  `FARO_SOURCEMAP_API_KEY`.
+- `-b, --bundle-id <id>`: Bundle id that matches the shipped JS bundle.
+  Falls back to `FARO_BUNDLE_ID`.
+- `--no-gzip`: POST the raw `.map` JSON instead of a gzipped tarball.
+- `-v, --verbose`: Verbose logging.
+- `--dry-run`: Show what would be uploaded and exit.
+- `-i, --max-upload-size <size>`: Maximum upload size in bytes (default: 30MB).
+- `-x, --proxy <url>`, `-U, --proxy-user <user:password>`: Same as the other subcommands.
+
+#### Connection settings precedence
+
+For each connection setting and the bundle id, resolution is "first non-empty wins": **CLI flag > matching env var**.
+
+| Setting          | CLI flag       | Env fallback              |
+| ---------------- | -------------- | ------------------------- |
+| Endpoint base    | `--endpoint`   | `FARO_SOURCEMAP_ENDPOINT` |
+| App id           | `--app-id`     | `FARO_SOURCEMAP_APP_ID`   |
+| Stack id         | `--stack-id`   | `FARO_SOURCEMAP_STACK_ID` |
+| API key          | `--api-key`    | `FARO_SOURCEMAP_API_KEY`  |
+| Bundle id        | `--bundle-id`  | `FARO_BUNDLE_ID`          |
+
+The map path (`--map`) is **required** and has no env fallback or autodetect.
+
+#### Validation and exit codes
+
+The `.map` is parsed and structurally validated before any upload attempt. The CLI never inspects or rewrites `mappings`, `sources`, or `sourcesContent`; if the `file` property is missing, it is set from the map filename so downstream symbolication can key onto it.
+
+| Exit code | Meaning |
+| --------- | ------- |
+| `0`       | Upload succeeded (or `--dry-run` finished). |
+| `1`       | Upload was attempted and the API rejected it (re-run with `--verbose`). |
+| `2`       | Pre-flight failed: missing required setting, missing/unparseable map, non-v3 map, or map exceeds the size limit. |
+| `3`       | The map parsed as v3 but its `sources` array is empty. Whatever produced the file emitted a structurally valid but useless map; investigate upstream of the CLI. Wire CI alarms onto this code separately. |
 
 ## License
 

--- a/packages/faro-cli/package.json
+++ b/packages/faro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/faro-cli",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "CLI for uploading sourcemaps to the Faro source map API",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/faro-cli/src/cli.ts
+++ b/packages/faro-cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
 import { uploadSourceMaps, generateCurlCommand, injectBundleId } from './index';
+import { runMetroUpload } from './metro';
 import { consoleInfoOrange, exportBundleIdToFile, JS_SOURCEMAP_PATTERN, randomString, cleanAppName } from '@grafana/faro-bundlers-shared';
 import path from 'path';
 import fs from 'fs';
@@ -263,6 +264,83 @@ Example:
       }
     } catch (err) {
       console.error('Error:', err);
+      process.exit(1);
+    }
+  });
+
+const metro = program
+  .command('metro')
+  .description('Metro (React Native) source map commands');
+
+metro
+  .command('upload')
+  .description('Upload a source map to the Faro source map API')
+  .requiredOption('--map <path>', 'Path to the .map file to upload')
+  .option('-e, --endpoint <url>', 'Faro source map API base URL (env: FARO_SOURCEMAP_ENDPOINT)')
+  .option('-a, --app-id <id>', 'Faro app id (env: FARO_SOURCEMAP_APP_ID)')
+  .option('-s, --stack-id <id>', 'Grafana Cloud stack id (env: FARO_SOURCEMAP_STACK_ID)')
+  .option('-k, --api-key <key>', 'Bearer API key (env: FARO_SOURCEMAP_API_KEY)')
+  .option('-b, --bundle-id <id>', 'Bundle id matching the shipped JS bundle (env: FARO_BUNDLE_ID)')
+  .option('--no-gzip', 'POST the raw .map JSON instead of a gzipped tarball')
+  .option('-v, --verbose', 'Verbose logging', false)
+  .option('--dry-run', 'Show what would be uploaded and exit', false)
+  .option('-i, --max-upload-size <size>', 'Maximum upload size in bytes (default: 30MB)', (value) => parseInt(value, 10))
+  .option('-x, --proxy <url>', 'Proxy URL to use for cURL requests')
+  .option('-U, --proxy-user <user:password>', 'Username and password for proxy authentication')
+  .addHelpText('after', `
+Examples:
+  # Fully explicit
+  $ faro-cli metro upload \\
+      --map path/to/your.map \\
+      --endpoint "$FARO_SOURCEMAP_ENDPOINT" \\
+      --app-id   "$FARO_SOURCEMAP_APP_ID" \\
+      --stack-id "$FARO_SOURCEMAP_STACK_ID" \\
+      --api-key  "$FARO_SOURCEMAP_API_KEY" \\
+      --bundle-id "$FARO_BUNDLE_ID"
+
+  # Env fallbacks (when the surrounding shell already exports FARO_*)
+  $ FARO_SOURCEMAP_ENDPOINT=… FARO_SOURCEMAP_APP_ID=… FARO_SOURCEMAP_STACK_ID=… \\
+    FARO_SOURCEMAP_API_KEY=…   FARO_BUNDLE_ID=$(git rev-parse HEAD) \\
+    faro-cli metro upload --map path/to/your.map
+
+Resolution: each connection setting and the bundle id come from the matching
+CLI flag (preferred) or the FARO_* env var (fallback). The path to the map
+is required (--map); this command never tries to construct it.`)
+  .action(async (options: {
+    map: string;
+    endpoint?: string;
+    appId?: string;
+    stackId?: string;
+    apiKey?: string;
+    bundleId?: string;
+    gzip: boolean;
+    verbose: boolean;
+    dryRun: boolean;
+    maxUploadSize?: number;
+    proxy?: string;
+    proxyUser?: string;
+  }) => {
+    try {
+      const code = await runMetroUpload({
+        map: options.map,
+        endpoint: options.endpoint,
+        appId: options.appId,
+        stackId: options.stackId,
+        apiKey: options.apiKey,
+        bundleId: options.bundleId,
+        // Commander's --no-gzip flag flips the implicit boolean to false; default is true.
+        gzip: options.gzip !== false,
+        verbose: !!options.verbose,
+        dryRun: !!options.dryRun,
+        maxUploadSize: options.maxUploadSize,
+        proxy: options.proxy,
+        proxyUser: options.proxyUser,
+      });
+      if (code !== 0) {
+        process.exit(code);
+      }
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
       process.exit(1);
     }
   });

--- a/packages/faro-cli/src/metro.ts
+++ b/packages/faro-cli/src/metro.ts
@@ -1,0 +1,218 @@
+import fs from 'fs';
+import path from 'path';
+
+import {
+  consoleInfoOrange,
+  ensureSourceMapFileProperty,
+  THIRTY_MB_IN_BYTES,
+} from '@grafana/faro-bundlers-shared';
+
+import { uploadCompressedSourceMaps, uploadSourceMap } from './index';
+
+/**
+ * Options for `faro-cli metro upload`.
+ *
+ * Connection settings (endpoint, appId, stackId, apiKey) and bundleId can
+ * each come from a CLI flag or the matching env var:
+ *
+ *   - --endpoint   / FARO_SOURCEMAP_ENDPOINT
+ *   - --app-id     / FARO_SOURCEMAP_APP_ID
+ *   - --stack-id   / FARO_SOURCEMAP_STACK_ID
+ *   - --api-key    / FARO_SOURCEMAP_API_KEY
+ *   - --bundle-id  / FARO_BUNDLE_ID
+ *
+ * Resolution is "first non-empty wins": CLI flag > env var. The path to
+ * the source map (`--map <path>`) is required; there is no env fallback
+ * or autodetect — the caller picks the file.
+ */
+export interface MetroUploadOptions {
+  /** Path to the source map file to upload. Required. */
+  map: string;
+  endpoint?: string;
+  appId?: string;
+  stackId?: string;
+  apiKey?: string;
+  bundleId?: string;
+  /** Defaults to true (gzipped tarball upload). `--no-gzip` flips it to a single-file POST. */
+  gzip: boolean;
+  verbose: boolean;
+  dryRun: boolean;
+  maxUploadSize?: number;
+  proxy?: string;
+  proxyUser?: string;
+}
+
+const trimmedString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+
+const firstNonEmpty = (...values: Array<string | undefined>): string => {
+  for (const value of values) {
+    const trimmed = trimmedString(value);
+    if (trimmed) return trimmed;
+  }
+  return '';
+};
+
+export interface ValidateMapResult {
+  ok: boolean;
+  /** 0 ok, 2 fatal config/parse, 3 v3 map with empty sources. */
+  exitCode: 0 | 2 | 3;
+  reason?: string;
+  version?: number;
+  sourcesCount?: number;
+}
+
+/**
+ * Validates a source map: file exists, parses as JSON, is v3, and has a
+ * non-empty `sources` array. The empty-sources case gets its own exit
+ * code (3) so callers can distinguish "structurally valid but useless"
+ * from "wrong file or unparseable".
+ */
+export const validateSourceMap = (mapPath: string): ValidateMapResult => {
+  if (!fs.existsSync(mapPath)) {
+    return {
+      ok: false,
+      exitCode: 2,
+      reason: `Source map not found: ${mapPath}`,
+    };
+  }
+
+  let parsed: { version?: unknown; sources?: unknown };
+  try {
+    parsed = JSON.parse(fs.readFileSync(mapPath, 'utf8'));
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      exitCode: 2,
+      reason: `Failed to parse map ${mapPath}: ${message}`,
+    };
+  }
+
+  if (parsed.version !== 3) {
+    return {
+      ok: false,
+      exitCode: 2,
+      reason: `Map ${mapPath} is not a v3 source map (got version=${String(parsed.version)}).`,
+      version: typeof parsed.version === 'number' ? parsed.version : undefined,
+    };
+  }
+
+  if (!Array.isArray(parsed.sources) || parsed.sources.length === 0) {
+    return {
+      ok: false,
+      exitCode: 3,
+      reason: `Map ${mapPath} has no sources — nothing to symbolicate against.`,
+      version: 3,
+      sourcesCount: 0,
+    };
+  }
+
+  return {
+    ok: true,
+    exitCode: 0,
+    version: 3,
+    sourcesCount: parsed.sources.length,
+  };
+};
+
+/**
+ * Implementation of `faro-cli metro upload`. Returns the process exit code
+ * rather than calling process.exit so the function stays unit-testable; the
+ * Commander action calls process.exit(code) when non-zero.
+ */
+export const runMetroUpload = async (opts: MetroUploadOptions): Promise<number> => {
+  const endpoint = firstNonEmpty(opts.endpoint, process.env.FARO_SOURCEMAP_ENDPOINT);
+  const appId = firstNonEmpty(opts.appId, process.env.FARO_SOURCEMAP_APP_ID);
+  const stackId = firstNonEmpty(opts.stackId, process.env.FARO_SOURCEMAP_STACK_ID);
+  const apiKey = firstNonEmpty(opts.apiKey, process.env.FARO_SOURCEMAP_API_KEY);
+  const bundleId = firstNonEmpty(opts.bundleId, process.env.FARO_BUNDLE_ID);
+
+  const missing: string[] = [];
+  if (!endpoint) missing.push('endpoint (--endpoint or FARO_SOURCEMAP_ENDPOINT)');
+  if (!appId) missing.push('appId (--app-id or FARO_SOURCEMAP_APP_ID)');
+  if (!stackId) missing.push('stackId (--stack-id or FARO_SOURCEMAP_STACK_ID)');
+  if (!apiKey) missing.push('apiKey (--api-key or FARO_SOURCEMAP_API_KEY)');
+  if (!bundleId) missing.push('bundleId (--bundle-id or FARO_BUNDLE_ID)');
+  if (missing.length > 0) {
+    process.stderr.write(`Missing required settings:\n  - ${missing.join('\n  - ')}\n`);
+    return 2;
+  }
+
+  const mapPath = path.resolve(opts.map);
+  const validation = validateSourceMap(mapPath);
+  if (!validation.ok) {
+    process.stderr.write(`${validation.reason ?? 'Validation failed.'}\n`);
+    return validation.exitCode;
+  }
+
+  ensureSourceMapFileProperty(mapPath, opts.verbose);
+
+  const stats = fs.statSync(mapPath);
+  const maxSize = opts.maxUploadSize && opts.maxUploadSize > 0 ? opts.maxUploadSize : THIRTY_MB_IN_BYTES;
+  if (stats.size > maxSize) {
+    process.stderr.write(
+      `Map ${mapPath} is ${stats.size} bytes (> ${maxSize} byte limit). Aborting upload.\n`
+    );
+    return 2;
+  }
+
+  const normalizedEndpoint = endpoint.replace(/\/$/, '');
+  const sourcemapEndpoint = `${normalizedEndpoint}/app/${appId}/sourcemaps/${bundleId}`;
+  const summary =
+    `\nfaro-cli metro upload\n` +
+    `  map        : ${mapPath}\n` +
+    `  size       : ${stats.size} bytes\n` +
+    `  sources    : ${validation.sourcesCount}\n` +
+    `  endpoint   : ${sourcemapEndpoint}\n` +
+    `  bundleId   : ${bundleId}\n` +
+    `  gzip       : ${opts.gzip ? 'yes' : 'no'}\n`;
+  process.stdout.write(summary);
+
+  if (opts.dryRun) {
+    process.stdout.write('\nDry run — not uploading.\n');
+    return 0;
+  }
+
+  if (opts.verbose) {
+    consoleInfoOrange(`Uploading source map ${mapPath}.`);
+  }
+
+  const ok = opts.gzip
+    ? await uploadCompressedSourceMaps({
+        endpoint: normalizedEndpoint,
+        appId,
+        apiKey,
+        stackId,
+        bundleId,
+        outputPath: path.dirname(mapPath),
+        files: [mapPath],
+        keepSourcemaps: true,
+        verbose: opts.verbose,
+        maxUploadSize: opts.maxUploadSize,
+        proxy: opts.proxy,
+        proxyUser: opts.proxyUser,
+      })
+    : await uploadSourceMap({
+        endpoint: normalizedEndpoint,
+        appId,
+        apiKey,
+        stackId,
+        bundleId,
+        filePath: mapPath,
+        filename: path.basename(mapPath),
+        keepSourcemaps: true,
+        verbose: opts.verbose,
+        maxUploadSize: opts.maxUploadSize,
+        proxy: opts.proxy,
+        proxyUser: opts.proxyUser,
+      });
+
+  if (!ok) {
+    process.stderr.write('\nUpload failed. Re-run with --verbose for the response status.\n');
+    return 1;
+  }
+
+  process.stdout.write('\nUpload complete.\n');
+  return 0;
+};

--- a/packages/faro-cli/src/test/metro.test.ts
+++ b/packages/faro-cli/src/test/metro.test.ts
@@ -1,0 +1,594 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { jest } from '@jest/globals';
+import { THIRTY_MB_IN_BYTES } from '@grafana/faro-bundlers-shared';
+
+jest.mock('../index', () => ({
+  uploadCompressedSourceMaps: jest.fn(),
+  uploadSourceMap: jest.fn(),
+}));
+
+import * as faroIndex from '../index';
+import { runMetroUpload, validateSourceMap } from '../metro';
+
+const FARO_ENV_VARS = [
+  'FARO_BUNDLE_ID',
+  'FARO_SOURCEMAP_API_KEY',
+  'FARO_SOURCEMAP_APP_ID',
+  'FARO_SOURCEMAP_ENDPOINT',
+  'FARO_SOURCEMAP_STACK_ID',
+];
+
+const stashedEnv: Record<string, string | undefined> = {};
+
+const createTempDir = (): string => fs.mkdtempSync(path.join(os.tmpdir(), 'faro-cli-metro-'));
+
+const removeTempDir = (dir: string): void => {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+};
+
+const writeValidMap = (dir: string, name = 'bundle.map'): string => {
+  const mapPath = path.join(dir, name);
+  fs.writeFileSync(
+    mapPath,
+    JSON.stringify({ version: 3, sources: ['a.js', 'b.js'], mappings: '' })
+  );
+  return mapPath;
+};
+
+const fullConnectionOpts = {
+  endpoint: 'https://faro.example.test',
+  appId: 'app',
+  stackId: 'stack',
+  apiKey: 'key',
+  bundleId: 'bundle',
+};
+
+beforeEach(() => {
+  for (const key of FARO_ENV_VARS) {
+    stashedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of FARO_ENV_VARS) {
+    if (stashedEnv[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = stashedEnv[key];
+    }
+  }
+  jest.restoreAllMocks();
+});
+
+describe('validateSourceMap', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  it('returns exit code 2 when the file is missing', () => {
+    const result = validateSourceMap(path.join(tempDir, 'missing.map'));
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.reason).toMatch(/Source map not found/);
+  });
+
+  it('returns exit code 2 on malformed JSON', () => {
+    const mapPath = path.join(tempDir, 'bad.map');
+    fs.writeFileSync(mapPath, '{ not json');
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.reason).toMatch(/Failed to parse map/);
+  });
+
+  it('returns exit code 2 for non-v3 source maps', () => {
+    const mapPath = path.join(tempDir, 'v2.map');
+    fs.writeFileSync(mapPath, JSON.stringify({ version: 2, sources: ['a.js'] }));
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(2);
+    expect(result.reason).toMatch(/not a v3 source map/);
+  });
+
+  it('returns exit code 3 for v3 maps with an empty sources array', () => {
+    const mapPath = path.join(tempDir, 'empty.map');
+    fs.writeFileSync(mapPath, JSON.stringify({ version: 3, sources: [] }));
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(3);
+    expect(result.sourcesCount).toBe(0);
+    expect(result.reason).toMatch(/has no sources/);
+  });
+
+  it('returns exit code 3 when sources is missing', () => {
+    const mapPath = path.join(tempDir, 'no-sources-key.map');
+    fs.writeFileSync(mapPath, JSON.stringify({ version: 3, mappings: '' }));
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(3);
+    expect(result.reason).toMatch(/has no sources/);
+  });
+
+  it('returns exit code 3 when sources is not an array', () => {
+    const mapPath = path.join(tempDir, 'bad-sources.map');
+    fs.writeFileSync(
+      mapPath,
+      JSON.stringify({ version: 3, sources: 'not-an-array', mappings: '' })
+    );
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(3);
+    expect(result.reason).toMatch(/has no sources/);
+  });
+
+  it('returns ok=true and the sources count for valid v3 maps', () => {
+    const mapPath = path.join(tempDir, 'good.map');
+    fs.writeFileSync(
+      mapPath,
+      JSON.stringify({ version: 3, sources: ['a.js', 'b.js', 'c.js'], mappings: '' })
+    );
+
+    const result = validateSourceMap(mapPath);
+    expect(result.ok).toBe(true);
+    expect(result.exitCode).toBe(0);
+    expect(result.version).toBe(3);
+    expect(result.sourcesCount).toBe(3);
+  });
+});
+
+describe('runMetroUpload — config resolution', () => {
+  let tempDir: string;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  const baseCliOpts = {
+    gzip: true,
+    verbose: false,
+    dryRun: true,
+  };
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    jest.mocked(faroIndex.uploadCompressedSourceMaps).mockClear();
+    jest.mocked(faroIndex.uploadSourceMap).mockClear();
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  it('returns exit code 2 listing every missing setting when no flags or env vars are set', async () => {
+    const mapPath = writeValidMap(tempDir);
+
+    const code = await runMetroUpload({ ...baseCliOpts, map: mapPath });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/Missing required settings/);
+    expect(stderr).toMatch(/--endpoint or FARO_SOURCEMAP_ENDPOINT/);
+    expect(stderr).toMatch(/--app-id or FARO_SOURCEMAP_APP_ID/);
+    expect(stderr).toMatch(/--stack-id or FARO_SOURCEMAP_STACK_ID/);
+    expect(stderr).toMatch(/--api-key or FARO_SOURCEMAP_API_KEY/);
+    expect(stderr).toMatch(/--bundle-id or FARO_BUNDLE_ID/);
+  });
+
+  it('falls back to FARO_* env vars when CLI flags are omitted (dry-run path)', async () => {
+    const mapPath = writeValidMap(tempDir);
+    process.env.FARO_SOURCEMAP_ENDPOINT = 'https://faro.example.test/api/v1';
+    process.env.FARO_SOURCEMAP_APP_ID = '123';
+    process.env.FARO_SOURCEMAP_STACK_ID = '456';
+    process.env.FARO_SOURCEMAP_API_KEY = 'env-key';
+    process.env.FARO_BUNDLE_ID = 'env-bundle';
+
+    const code = await runMetroUpload({ ...baseCliOpts, map: mapPath });
+
+    expect(code).toBe(0);
+    const stdout = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdout).toMatch(
+      /endpoint   : https:\/\/faro\.example\.test\/api\/v1\/app\/123\/sourcemaps\/env-bundle/
+    );
+    expect(stdout).toMatch(/bundleId   : env-bundle/);
+    expect(stdout).toMatch(/Dry run/);
+    // Sanity check: platform tag flags were removed, so the summary must not
+    // mention them (regression guard against re-introducing the platform line).
+    expect(stdout).not.toMatch(/platform/);
+  });
+
+  it('trims whitespace on FARO_* env values', async () => {
+    const mapPath = writeValidMap(tempDir);
+    process.env.FARO_SOURCEMAP_ENDPOINT = '  https://trim.example.test/api  ';
+    process.env.FARO_SOURCEMAP_APP_ID = '123';
+    process.env.FARO_SOURCEMAP_STACK_ID = '456';
+    process.env.FARO_SOURCEMAP_API_KEY = 'key';
+    process.env.FARO_BUNDLE_ID = 'bun';
+
+    const code = await runMetroUpload({ ...baseCliOpts, map: mapPath });
+
+    expect(code).toBe(0);
+    const stdout = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdout).toMatch(
+      /endpoint   : https:\/\/trim\.example\.test\/api\/app\/123\/sourcemaps\/bun/
+    );
+  });
+
+  it('CLI flags win over env vars', async () => {
+    const mapPath = writeValidMap(tempDir);
+    process.env.FARO_SOURCEMAP_ENDPOINT = 'https://env.example.test';
+    process.env.FARO_SOURCEMAP_APP_ID = 'env-app';
+    process.env.FARO_SOURCEMAP_STACK_ID = 'env-stack';
+    process.env.FARO_SOURCEMAP_API_KEY = 'env-key';
+    process.env.FARO_BUNDLE_ID = 'env-bundle';
+
+    const code = await runMetroUpload({
+      ...baseCliOpts,
+      map: mapPath,
+      endpoint: 'https://flag.example.test/api/v1/',
+      appId: 'flag-app',
+      stackId: 'flag-stack',
+      apiKey: 'flag-key',
+      bundleId: 'flag-bundle',
+    });
+
+    expect(code).toBe(0);
+    const stdout = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    // Trailing slash on the endpoint should be normalized away.
+    expect(stdout).toMatch(
+      /endpoint   : https:\/\/flag\.example\.test\/api\/v1\/app\/flag-app\/sourcemaps\/flag-bundle/
+    );
+    expect(stdout).toMatch(/bundleId   : flag-bundle/);
+  });
+
+  it('accepts an arbitrary map filename — the CLI does not assume any specific filename', async () => {
+    const mapPath = writeValidMap(tempDir, 'arbitrary-name.bundle.map');
+
+    const code = await runMetroUpload({
+      ...baseCliOpts,
+      map: mapPath,
+      endpoint: 'https://faro.example.test',
+      appId: 'app',
+      stackId: 'stack',
+      apiKey: 'key',
+      bundleId: 'bundle',
+    });
+
+    expect(code).toBe(0);
+    const stdout = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdout).toMatch(/arbitrary-name\.bundle\.map/);
+  });
+
+  it('propagates validateSourceMap exit code 3 for v3 maps with empty sources', async () => {
+    const mapPath = path.join(tempDir, 'empty.map');
+    fs.writeFileSync(mapPath, JSON.stringify({ version: 3, sources: [] }));
+
+    const code = await runMetroUpload({
+      ...baseCliOpts,
+      map: mapPath,
+      endpoint: 'https://faro.example.test',
+      appId: 'app',
+      stackId: 'stack',
+      apiKey: 'key',
+      bundleId: 'bundle',
+    });
+
+    expect(code).toBe(3);
+  });
+});
+
+describe('runMetroUpload — validation errors (integration)', () => {
+  let tempDir: string;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    jest.mocked(faroIndex.uploadCompressedSourceMaps).mockClear();
+    jest.mocked(faroIndex.uploadSourceMap).mockClear();
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  it('returns exit code 2 when the map file is missing', async () => {
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: true,
+      map: path.join(tempDir, 'missing.map'),
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/Source map not found/);
+  });
+
+  it('returns exit code 2 when the map JSON is invalid', async () => {
+    const mapPath = path.join(tempDir, 'bad.map');
+    fs.writeFileSync(mapPath, '{');
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: true,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/Failed to parse map/);
+  });
+
+  it('returns exit code 2 when the map is not v3', async () => {
+    const mapPath = path.join(tempDir, 'v2.map');
+    fs.writeFileSync(mapPath, JSON.stringify({ version: 2, sources: ['a.js'] }));
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: true,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/not a v3 source map/);
+  });
+
+  it('does not call upload helpers when validation fails', async () => {
+    const mapPath = path.join(tempDir, 'bad.map');
+    fs.writeFileSync(mapPath, '{');
+
+    await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(faroIndex.uploadCompressedSourceMaps).not.toHaveBeenCalled();
+    expect(faroIndex.uploadSourceMap).not.toHaveBeenCalled();
+  });
+});
+
+describe('runMetroUpload — file size limit', () => {
+  let tempDir: string;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    jest.mocked(faroIndex.uploadCompressedSourceMaps).mockClear().mockResolvedValue(true);
+    jest.mocked(faroIndex.uploadSourceMap).mockClear().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  it('returns exit code 2 when the map exceeds the default max size', async () => {
+    const mapPath = writeValidMap(tempDir);
+    jest.spyOn(fs, 'statSync').mockReturnValue({ size: THIRTY_MB_IN_BYTES + 1 } as fs.Stats);
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/byte limit/);
+    expect(faroIndex.uploadCompressedSourceMaps).not.toHaveBeenCalled();
+  });
+
+  it('returns exit code 2 when the map exceeds a custom maxUploadSize', async () => {
+    const mapPath = writeValidMap(tempDir);
+    jest.spyOn(fs, 'statSync').mockReturnValue({ size: 500 } as fs.Stats);
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      maxUploadSize: 400,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    expect(faroIndex.uploadCompressedSourceMaps).not.toHaveBeenCalled();
+  });
+
+  it('uses default limit when maxUploadSize is zero', async () => {
+    const mapPath = writeValidMap(tempDir);
+    jest.spyOn(fs, 'statSync').mockReturnValue({ size: THIRTY_MB_IN_BYTES + 1 } as fs.Stats);
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      maxUploadSize: 0,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(new RegExp(`${THIRTY_MB_IN_BYTES}`));
+  });
+});
+
+describe('runMetroUpload — upload delegation', () => {
+  let tempDir: string;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    tempDir = createTempDir();
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    jest.mocked(faroIndex.uploadCompressedSourceMaps).mockReset().mockResolvedValue(true);
+    jest.mocked(faroIndex.uploadSourceMap).mockReset().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    removeTempDir(tempDir);
+  });
+
+  it('calls uploadCompressedSourceMaps when gzip is true', async () => {
+    const mapPath = writeValidMap(tempDir);
+    const resolvedMap = path.resolve(mapPath);
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      endpoint: 'https://e.test/',
+      appId: 'aid',
+      stackId: 'sid',
+      apiKey: 'secret',
+      bundleId: 'bid',
+    });
+
+    expect(code).toBe(0);
+    expect(faroIndex.uploadCompressedSourceMaps).toHaveBeenCalledTimes(1);
+    expect(faroIndex.uploadSourceMap).not.toHaveBeenCalled();
+    expect(faroIndex.uploadCompressedSourceMaps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://e.test',
+        appId: 'aid',
+        stackId: 'sid',
+        apiKey: 'secret',
+        bundleId: 'bid',
+        outputPath: path.dirname(resolvedMap),
+        files: [resolvedMap],
+        keepSourcemaps: true,
+        verbose: false,
+      })
+    );
+    const stdout = stdoutSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stdout).toMatch(/Upload complete/);
+  });
+
+  it('calls uploadSourceMap when gzip is false', async () => {
+    const mapPath = writeValidMap(tempDir, 'main.js.map');
+    const resolvedMap = path.resolve(mapPath);
+
+    const code = await runMetroUpload({
+      gzip: false,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(0);
+    expect(faroIndex.uploadSourceMap).toHaveBeenCalledTimes(1);
+    expect(faroIndex.uploadCompressedSourceMaps).not.toHaveBeenCalled();
+    expect(faroIndex.uploadSourceMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: 'https://faro.example.test',
+        filePath: resolvedMap,
+        filename: 'main.js.map',
+        keepSourcemaps: true,
+      })
+    );
+  });
+
+  it('forwards proxy and proxyUser to the upload helper', async () => {
+    const mapPath = writeValidMap(tempDir);
+
+    await runMetroUpload({
+      gzip: false,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      proxy: 'http://proxy.example',
+      proxyUser: 'user:pass',
+      ...fullConnectionOpts,
+    });
+
+    expect(faroIndex.uploadSourceMap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        proxy: 'http://proxy.example',
+        proxyUser: 'user:pass',
+      })
+    );
+  });
+
+  it('forwards maxUploadSize to the upload helper', async () => {
+    const mapPath = writeValidMap(tempDir);
+
+    await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      maxUploadSize: 9_000_000,
+      ...fullConnectionOpts,
+    });
+
+    expect(faroIndex.uploadCompressedSourceMaps).toHaveBeenCalledWith(
+      expect.objectContaining({ maxUploadSize: 9_000_000 })
+    );
+  });
+
+  it('returns exit code 1 when upload returns false', async () => {
+    const mapPath = writeValidMap(tempDir);
+    jest.mocked(faroIndex.uploadCompressedSourceMaps).mockResolvedValueOnce(false);
+
+    const code = await runMetroUpload({
+      gzip: true,
+      verbose: false,
+      dryRun: false,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(code).toBe(1);
+    const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
+    expect(stderr).toMatch(/Upload failed/);
+  });
+
+  it('passes verbose=true through to the gzip upload helper', async () => {
+    const mapPath = writeValidMap(tempDir);
+
+    await runMetroUpload({
+      gzip: true,
+      verbose: true,
+      dryRun: false,
+      map: mapPath,
+      ...fullConnectionOpts,
+    });
+
+    expect(faroIndex.uploadCompressedSourceMaps).toHaveBeenCalledWith(
+      expect.objectContaining({ verbose: true })
+    );
+  });
+});

--- a/packages/faro-esbuild/src/test/index.test.ts
+++ b/packages/faro-esbuild/src/test/index.test.ts
@@ -81,7 +81,11 @@ describe('Faro Esbuild Plugin', () => {
   test('basic bundleId injection test', async () => {
     const { code } = await runEsbuild({ bundleId: 'test' });
 
-    expect(code.startsWith(`(function(){try{var g=typeof window!=="undefined"?window:typeof global!=="undefined"?global:typeof self!=="undefined"?self:{};g["__faroBundleId_esbuild-test-app"]="test"`)).toBeTruthy();
+    expect(
+      code.startsWith(
+        `(function(){try{var g=typeof globalThis!=="undefined"?globalThis:typeof global!=="undefined"?global:typeof window!=="undefined"?window:typeof self!=="undefined"?self:{};g["__faroBundleId_esbuild-test-app"]="test"`
+      )
+    ).toBeTruthy();
   });
 
   test('custom bundleId is correctly injected', async () => {
@@ -117,7 +121,8 @@ describe('Faro Esbuild Plugin', () => {
     const { code } = await runEsbuild({ bundleId: 'test' });
 
     // create a simple regex to check code starts with the bundle ID snippet
-    const bundleIdRegex = /^\(function\(\)\{try\{var g=typeof window!=="undefined"\?window:typeof global!=="undefined"\?global:typeof self!=="undefined"\?self:\{\};g\["__faroBundleId_esbuild-test-app"\]="test"\}catch\(l\)\{\}\}\)\(\);/;
+    const bundleIdRegex =
+      /^\(function\(\)\{try\{var g=typeof globalThis!=="undefined"\?globalThis:typeof global!=="undefined"\?global:typeof window!=="undefined"\?window:typeof self!=="undefined"\?self:\{\};g\["__faroBundleId_esbuild-test-app"\]="test"\}catch\(l\)\{\}\}\)\(\);/;
 
     expect(code).toMatch(bundleIdRegex);
   });

--- a/packages/faro-metro-plugin/CHANGELOG.md
+++ b/packages/faro-metro-plugin/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Initial release: Metro `customSerializer` wrapper, Faro bundle id preamble, source map line shift, release upload to the Faro source map API, optional `sourceMapFile` for the generated map’s `file` field.
+- Unit tests cover release `sourcemapEndpoint` (`…/app/{appId}/sourcemaps/{bundleId}`), gzip vs non-gzip upload helpers, hashed bundle ids over the length limit, non-success upload handling, and a Path A–style source map fixture parse check.
+- When Metro omits the source map `file` field, the serializer sets it from `sourceMapFile` (default `bundle.js`) so emitted maps and uploads stay aligned with the RN SDK’s `releaseBundleFilename`.
+- With `verbose: true`, log when upload is skipped because the map filename did not match the shared JS source map pattern (fixed in `@grafana/faro-bundlers-shared` for `*.bundle.map` / `*.jsbundle.map`).

--- a/packages/faro-metro-plugin/CHANGELOG.md
+++ b/packages/faro-metro-plugin/CHANGELOG.md
@@ -2,7 +2,5 @@
 
 ## 0.1.0
 
-- Initial release: Metro `customSerializer` wrapper, Faro bundle id preamble, source map line shift, release upload to the Faro source map API, optional `sourceMapFile` for the generated map’s `file` field.
-- Unit tests cover release `sourcemapEndpoint` (`…/app/{appId}/sourcemaps/{bundleId}`), gzip vs non-gzip upload helpers, hashed bundle ids over the length limit, non-success upload handling, and a Path A–style source map fixture parse check.
-- When Metro omits the source map `file` field, the serializer sets it from `sourceMapFile` (default `bundle.js`) so emitted maps and uploads stay aligned with the RN SDK’s `releaseBundleFilename`.
-- With `verbose: true`, log when upload is skipped because the map filename did not match the shared JS source map pattern (fixed in `@grafana/faro-bundlers-shared` for `*.bundle.map` / `*.jsbundle.map`).
+- Initial release of the plugin, including a Metro `customSerializer` wrapper, Faro bundle id preamble, Hermes/source map line shift, optional `sourceMapFile` so emitted maps stay aligned with the React Native SDK’s `releaseBundleFilename`, and optional verbose logging when upload is skipped because the map filename does not match the expected bundle map patterns.
+- Upload composed Metro/Hermes release source maps with `faro-cli metro upload` from `@grafana/faro-cli`; the `faro-upload-source-map` binary delegates to it for Gradle hooks and scripts.

--- a/packages/faro-metro-plugin/LICENSE
+++ b/packages/faro-metro-plugin/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/faro-metro-plugin/README.md
+++ b/packages/faro-metro-plugin/README.md
@@ -1,12 +1,27 @@
-# Faro source map upload — Metro (React Native)
+# Faro source maps — Metro (React Native)
 
-This package wraps **Metro** so release bundles get:
+This package configures **Metro** so release bundles work end-to-end with Grafana Frontend Observability:
 
-1. A **Faro bundle id** preamble at the top of the JS bundle (same mechanism as `@grafana/faro-webpack-plugin`), so `meta.app.bundleId` matches the uploaded source map bundle in `@grafana/faro-web-sdk` / `@grafana/faro-react-native`.
-2. A **source map** whose generated lines are shifted to account for that preamble.
-3. Optional **upload** of the map to the Grafana Frontend Observability source map API (release builds only, same auth model as other Faro bundler plugins).
+1. **Bundle id preamble** — Same idea as `@grafana/faro-webpack-plugin`: a small snippet at the top of the JS bundle sets `meta.app.bundleId` so it matches the source map record in `@grafana/faro-react-native` / `@grafana/faro-web-sdk`.
 
-> `appName` here must match the **`app.name`** you pass to `initializeFaro` in the React Native SDK.
+2. **Source map shape** — Metro emits the packager map in the form Hermes precompile, Hermes interpreter, or JSC expects (see [Hermes modes](#hermes-modes)).
+
+3. **Upload** — Happens **after** the native pipeline produces the **composed** map (`hermesc` + `compose-source-maps.js`). Metro does **not** upload; the composed map is the one the collector uses for symbolication.
+
+---
+
+## End-to-end flow
+
+| Step | Where |
+|------|--------|
+| 1 | Install `@grafana/faro-metro-plugin` and wrap `metro.config.js` with `withFaroConfig`. |
+| 2 | Install and initialise `@grafana/faro-react-native` with the **same `app.name`** as `appName` in Metro options. |
+| 3 | For **release** builds, export `FARO_BUNDLE_ID` and `FARO_SOURCEMAP_*` (see [Environment variables](#environment-variables)). |
+| 4 | <ul><li><strong>Android:</strong> Upload runs from Gradle after the composed map is produced (see <a href="#android">Android</a>).</li><li><strong>iOS:</strong> Upload after the composed map exists via Xcode automation that calls this package’s <code>bin/</code> helpers (Release-only), or manually with <code>faro-cli metro upload</code> (see <a href="#ios-upload">iOS upload</a>).</li></ul> |
+
+Symbolication runs **server-side in the Faro collector**: it loads the map by `bundleId` from the source map API and resolves stack frames.
+
+---
 
 ## Installation
 
@@ -16,7 +31,11 @@ npm install --save-dev @grafana/faro-metro-plugin
 yarn add --dev @grafana/faro-metro-plugin
 ```
 
-## Usage
+Also add **`@grafana/faro-react-native`** as a runtime dependency if you use the standard Android Gradle wiring.
+
+---
+
+## Metro configuration
 
 In `metro.config.js`:
 
@@ -37,25 +56,153 @@ const faroOpts = {
 module.exports = mergeConfig(getDefaultConfig(__dirname), withFaroConfig({}, faroOpts));
 ```
 
-### Environment variables
+**Metro uses:** `appName`, `bundleId` (or `FARO_BUNDLE_ID`), optional `hermes`, `sourceMapFile`, `skipUpload`, `verbose`.  
+The shared option shape also requires `endpoint`, `appId`, `stackId`, `apiKey`; keep them aligned with **Frontend Observability → Settings → Source Maps** and with the same values you pass into **`faro-cli metro upload`** or your Gradle / Xcode automation.
+
+When using **`@sentry/react-native`**, wrap **Sentry outside** and **Faro inside** so the preamble stays first, for example:
+
+`mergeConfig(getDefaultConfig(__dirname), withSentryConfig(withFaroConfig({}, faroOpts)))` — check Sentry’s docs for your RN version.
+
+---
+
+## Environment variables
 
 | Variable | Purpose |
 |----------|---------|
-| `FARO_SOURCEMAP_API_KEY` | Bearer API key for uploads (often set in CI). |
-| `FARO_BUNDLE_ID` | **Release:** stable id for this build (commit SHA, CI build number, etc.). Omit in dev. |
-| `FARO_SKIP_SOURCEMAP_UPLOAD` | Set to `1` or `true` (case-insensitive) to skip upload while keeping the preamble and map fixes. |
+| `FARO_SOURCEMAP_API_KEY`          | Bearer token for the upload HTTP request (Gradle, Xcode automation, or CLI).                                                                                                                                                                                                       |
+| `FARO_SOURCEMAP_ENDPOINT`       | Collector API base URL (Gradle, Xcode automation, or CLI).                                                                                                                                                                                                                           |
+| `FARO_SOURCEMAP_APP_ID`         | App id segment in the upload URL (Gradle, Xcode automation, or CLI).                                                                                                                                                                                                                  |
+| `FARO_SOURCEMAP_STACK_ID`       | Stack id for the upload (Gradle, Xcode automation, or CLI).                                                                                                                                                                                                                           |
+| `FARO_BUNDLE_ID` | **Release:** Stable build id (commit SHA, CI build number, …). Must match what Metro baked into the bundle. Omit for local dev. |
+| `FARO_SKIP_SOURCEMAP_UPLOAD` | If `1` or `true`, native upload steps skip while still building; preamble and map shaping unchanged. Also participates in dev bundle-id behaviour when no explicit id is set. |
+| `FARO_DISABLE_HERMES_PRECOMPILE` | **Rare.** Only if Metro runs with **`dev: false`** but the JS you ship **never** goes through the usual native **`hermesc` + `compose-source-maps.js`** step (see [When Hermes skips native precompile](#when-hermes-skips-native-precompile)). **Dev** does not need this—Metro `dev: true` is detected automatically. **Normal** Android/iOS **release** builds must **leave this unset**. |
 
-Uploads are skipped when `NODE_ENV=development`, when `skipUpload: true`, or when building with Metro `dev: true`, unless you override `skipUpload`.
+`skipUpload: true`, `NODE_ENV=development`, Metro `dev: true`, and `FARO_SKIP_SOURCEMAP_UPLOAD` affect placeholder bundle ids and whether native upload steps run; none of them perform upload from Metro.
 
-### Optional: `sourceMapFile`
+### When Hermes skips native precompile
 
-The plugin writes a temporary `*.map` whose basename (without `.map`) becomes the source map **`file`** field (default **`bundle.js`**). Hermes release stacks often omit a real filename; `@grafana/faro-react-native` defaults `releaseBundleFilename` to **`bundle.js`** so stack frames resolve to the same key the API stores.
+Set **`FARO_DISABLE_HERMES_PRECOMPILE`** only in the situations below. Everyone else should **omit** it.
 
-If you change this, set the same value in the RN SDK via `releaseBundleFilename`.
+**Default:** leave it **unset**. That matches **stock** React Native: e.g. Android `./gradlew assembleRelease` (or your project’s equivalent that runs `bundleReleaseJsAndAssets` and the RN Hermes/map steps) and iOS **Release** archive—those pipelines **always** precompile Hermes bytecode and compose maps after Metro.
 
-### CLI sanity check: `react-native bundle`
+Metro already chooses the right map shape for **development** (`dev: true` → Hermes “runtime” / flattened map). You do **not** need this variable for `npx react-native start` or day-to-day debugging.
 
-Use the same **`appName`** / **`FARO_BUNDLE_ID`** / upload settings as CI. Typical outputs:
+**Set the variable (usually only in CI or a dedicated script)** when **all** of the following are true:
+
+1. You produce a **production** bundle with Metro **`dev: false`** (same as a release JS bundle).
+2. That bundle is loaded in Hermes in a way where stack traces look like **dev Hermes** (`line 1` + UTF-8 **byte column** in the JS source text)—not like a map meant for the **composed** Hermes bytecode pipeline.
+3. Your pipeline **does not** run the standard post-Metro **`hermesc` + `compose-source-maps.js`** flow that `assembleRelease` / a typical Xcode Release build performs.
+
+**Concrete-style example (illustrative, not a single official command):** a team runs only `npx react-native bundle --platform android --dev false …` in CI, ships `index.android.bundle` + `.map` through a **custom** native shell or distribution path, and **never** invokes Gradle’s release Hermes steps that merge Metro’s map with the bytecode map. Production crashes then behave like **Hermes-on-raw-bundle** symbolication; setting `FARO_DISABLE_HERMES_PRECOMPILE=1` for **that** Metro job makes the emitted map match those stacks. The same app built with a **normal** `./gradlew assembleRelease` must **not** set this—doing so can break `compose-source-maps` (multi-line packager map is required there).
+
+**Who sets it:** not every developer—only the maintainer of the **non-standard** build defines it once (e.g. export in the CI job or script that runs the odd Metro-only release bundle).
+
+---
+
+## Hermes modes
+
+How Metro output is shaped depends on the scenario. The plugin **always** injects the Faro bundle id line at the top of the JS; it **reshapes** the source map only when the engine reports positions in a different coordinate system.
+
+| Scenario | What the plugin is doing (plain language) | What you end up with |
+|----------|---------------------------------------------|----------------------|
+| **Release, Hermes (normal RN)** | Tags the bundle with a Faro id; **lightly** fixes the map so that extra line doesn’t break positions; leaves a **normal** multi-line map so the native build can still merge Metro + Hermes maps. | JS **with** id + map ready for the **native** Hermes/compose step; production symbolication usually uses the **final** map from that pipeline. |
+| **Dev, Metro + Hermes** | Tags the bundle; **rewrites** the map so Hermes dev errors (one line + byte offset) can still be mapped back to source. | JS **with** id + **flattened** map that matches **live dev** stacks. |
+| **JSC only** | Tags the bundle; **only** shifts line numbers for that id line—no Hermes-specific map rewrite. | JS **with** id + **classic** line/column map. |
+
+We always label the bundle; we only “reshape” the source map when the JavaScript engine reports crashes in a different coordinate system (Hermes in dev).
+
+**Implementation (reference):** internal mode names and triggers:
+
+| Mode | When | Map shape from Metro |
+|------|------|----------------------|
+| `precompiled` | `dev: false`, Hermes enabled (`hermes !== false`), `FARO_DISABLE_HERMES_PRECOMPILE` unset — **typical Android/iOS release** | Multi-line map with `+1` line shift on generated lines |
+| `runtime` | `dev: true` **or** `FARO_DISABLE_HERMES_PRECOMPILE` set | Single-line mappings with UTF-8 byte offsets on line 1 |
+| `jsc` | `hermes: false` in plugin options | Multi-line map with `+1` line shift |
+
+For **`precompiled`**, Xcode/Gradle run `compose-source-maps.js` after Metro. That step needs the **multi-line** packager map; flattening it at Metro would break the composed map (`sources` empty) and symbolication.
+
+Upload always happens **after** compose: Gradle on Android, Xcode automation calling this package’s **`bin/`** on iOS (Release-only), or **`faro-cli metro upload`** where you drive uploads yourself.
+
+---
+
+## Android
+
+### With `@grafana/faro-react-native`
+
+1. Dependencies: `@grafana/faro-react-native` (app) and `@grafana/faro-metro-plugin` (dev).
+2. Configure Metro as in [Metro configuration](#metro-configuration).
+3. Export `FARO_BUNDLE_ID` and all `FARO_SOURCEMAP_*` vars before release builds.
+4. Run a normal release workflow (`yarn android --mode=release`, `installRelease`, `assembleRelease`, `bundleRelease`, …).
+
+React Native autolinks the SDK’s Android library. Its **`android/build.gradle`** registers **`faroUploadComposedSourceMapAndroidRelease`** on your **`:app`** project and attaches it as a finaliser of **`bundleReleaseJsAndAssets`** / **`createBundleReleaseJsAndAssets`** after `gradle.projectsEvaluated`.
+
+You **do not** edit `android/app/build.gradle` for this path.
+
+The task runs **`node_modules/@grafana/faro-metro-plugin/bin/faro-upload-source-map.js`**, which invokes **`faro-cli metro upload`** with `--map` pointing at:
+
+`android/app/build/generated/sourcemaps/react/release/index.android.bundle.map`
+
+and passes `--bundle-id`, `--endpoint`, `--app-id`, `--stack-id`, `--api-key` from the Gradle environment.
+
+If the shim is missing, the composed map does not exist, any required env var is missing, or `FARO_SKIP_SOURCEMAP_UPLOAD` is set, the task logs and **skips** — it does not fail the build.
+
+### Without `@grafana/faro-react-native`
+
+Use the same Gradle behaviour by applying this package’s script from **`android/app/build.gradle`**:
+
+```groovy
+apply from: file("../../node_modules/@grafana/faro-metro-plugin/android/source-map-upload.gradle")
+```
+
+Adjust the relative path if your `node_modules` layout differs. Export the same env vars as above before release builds.
+
+---
+
+## iOS upload
+
+**Layout (same idea as Android):** Anything executable lives in **`@grafana/faro-metro-plugin`** under **`bin/`** (for example the existing **`faro-upload-source-map`** entry that forwards to **`faro-cli metro upload`**). **`@grafana/faro-react-native`** should only wire Xcode — for example a React Native **`scriptPhases`** hook — that **`exec`s those paths under `node_modules/@grafana/faro-metro-plugin/bin/`**, not ship duplicate scripts inside the SDK.
+
+**Release-only:** That Xcode step **must** no-op on non-Release configurations (inspect Xcode’s **`CONFIGURATION`** / equivalent). Debug and simulator-oriented builds stay quiet and never call the upload CLI.
+
+**Manual / CI (when nothing uploads the map for you):** Use this if the **automatic** path does not run—for example you have **not** wired the Android Gradle task or an Xcode **Release** script phase that calls **`node_modules/@grafana/faro-metro-plugin/bin/`**, upload steps are skipped (`FARO_SKIP_SOURCEMAP_UPLOAD`, missing env vars), or CI builds the composed map in a job **without** those hooks. Invoke **`faro-cli metro upload`** after Release produces the **composed** map:
+
+```bash
+npx faro-cli metro upload \
+  --map "$BUILD_DIR/main.jsbundle.map" \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id "$FARO_SOURCEMAP_APP_ID" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --api-key "$FARO_SOURCEMAP_API_KEY" \
+  --bundle-id "$FARO_BUNDLE_ID"
+```
+
+**Android** the same way—only when Gradle is **not** already running the upload finaliser (or you need a standalone CI step using the **same** flags as Gradle):
+
+```bash
+npx faro-cli metro upload \
+  --map android/app/build/generated/sourcemaps/react/release/index.android.bundle.map \
+  --endpoint "$FARO_SOURCEMAP_ENDPOINT" \
+  --app-id "$FARO_SOURCEMAP_APP_ID" \
+  --stack-id "$FARO_SOURCEMAP_STACK_ID" \
+  --api-key "$FARO_SOURCEMAP_API_KEY" \
+  --bundle-id "$FARO_BUNDLE_ID"
+```
+
+Flags accept the matching `FARO_*` env fallbacks where documented in [`@grafana/faro-cli`](../faro-cli/README.md#uploading-react-native-metro--hermes-composed-source-maps).
+
+The CLI rejects composed maps with **empty `sources`** (usually wrong Metro map shape for `compose-source-maps.js`) and exits with code **`3`**.
+
+---
+
+## Optional: `sourceMapFile`
+
+Metro writes the map’s **`file`** field from this basename (default **`bundle.js`**). Align with **`releaseBundleFilename`** in `@grafana/faro-react-native` if you change it.
+
+---
+
+## Sanity check: `react-native bundle`
+
+Match **`appName`**, **`FARO_BUNDLE_ID`**, and upload settings with CI.
 
 **Android**
 
@@ -70,7 +217,7 @@ npx react-native bundle \
   --assets-dest dist/android-release/res
 ```
 
-**iOS** — set **`sourceMapFile`** to **`main.jsbundle`** for this invocation (here via env) so the map’s **`file`** field matches iOS Hermes stacks and **`releaseBundleFilename`**:
+**iOS** — Set **`sourceMapFile`** to **`main.jsbundle`** for this run so the map’s **`file`** matches stacks and **`releaseBundleFilename`**:
 
 ```bash
 FARO_PLATFORM=ios npx react-native bundle \
@@ -83,8 +230,10 @@ FARO_PLATFORM=ios npx react-native bundle \
   --assets-dest dist/ios-release/assets
 ```
 
-**Verify:** preamble at the top of the `.jsbundle` / `.bundle` sets **`__faroBundleId_<appName>`**; the **`.map`** parses as JSON with **`version` 3**, non-empty **`sources`**, and **`file`** equal to the bundle basename you configured (`index.android.bundle` vs `main.jsbundle`).
+**Check:** Bundle starts with **`__faroBundleId_<appName>`**; `.map` is JSON **`version` 3**, non-empty **`sources`**, **`file`** matching your bundle basename.
+
+---
 
 ## Grafana UI
 
-In **Frontend Observability → your app → Settings**, use the **Source Maps** tab for `endpoint`, `appId`, `stackId`, and install snippets (Metro is included for mobile apps).
+In **Frontend Observability → your app → Settings**, open **Source Maps** for `endpoint`, `appId`, `stackId`, and Metro-oriented snippets.

--- a/packages/faro-metro-plugin/README.md
+++ b/packages/faro-metro-plugin/README.md
@@ -1,0 +1,90 @@
+# Faro source map upload — Metro (React Native)
+
+This package wraps **Metro** so release bundles get:
+
+1. A **Faro bundle id** preamble at the top of the JS bundle (same mechanism as `@grafana/faro-webpack-plugin`), so `meta.app.bundleId` matches the uploaded source map bundle in `@grafana/faro-web-sdk` / `@grafana/faro-react-native`.
+2. A **source map** whose generated lines are shifted to account for that preamble.
+3. Optional **upload** of the map to the Grafana Frontend Observability source map API (release builds only, same auth model as other Faro bundler plugins).
+
+> `appName` here must match the **`app.name`** you pass to `initializeFaro` in the React Native SDK.
+
+## Installation
+
+```bash
+npm install --save-dev @grafana/faro-metro-plugin
+# or
+yarn add --dev @grafana/faro-metro-plugin
+```
+
+## Usage
+
+In `metro.config.js`:
+
+```javascript
+const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
+const withFaroConfig = require('@grafana/faro-metro-plugin').default;
+
+const faroOpts = {
+  appName: 'MyApp',
+  endpoint: 'https://your-collector.example.com/api/v1',
+  appId: 'your-app-id',
+  stackId: 'your-stack-id',
+  apiKey: process.env.FARO_SOURCEMAP_API_KEY,
+  bundleId: process.env.FARO_BUNDLE_ID,
+  verbose: true,
+};
+
+module.exports = mergeConfig(getDefaultConfig(__dirname), withFaroConfig({}, faroOpts));
+```
+
+### Environment variables
+
+| Variable | Purpose |
+|----------|---------|
+| `FARO_SOURCEMAP_API_KEY` | Bearer API key for uploads (often set in CI). |
+| `FARO_BUNDLE_ID` | **Release:** stable id for this build (commit SHA, CI build number, etc.). Omit in dev. |
+| `FARO_SKIP_SOURCEMAP_UPLOAD` | Set to `1` or `true` (case-insensitive) to skip upload while keeping the preamble and map fixes. |
+
+Uploads are skipped when `NODE_ENV=development`, when `skipUpload: true`, or when building with Metro `dev: true`, unless you override `skipUpload`.
+
+### Optional: `sourceMapFile`
+
+The plugin writes a temporary `*.map` whose basename (without `.map`) becomes the source map **`file`** field (default **`bundle.js`**). Hermes release stacks often omit a real filename; `@grafana/faro-react-native` defaults `releaseBundleFilename` to **`bundle.js`** so stack frames resolve to the same key the API stores.
+
+If you change this, set the same value in the RN SDK via `releaseBundleFilename`.
+
+### CLI sanity check: `react-native bundle`
+
+Use the same **`appName`** / **`FARO_BUNDLE_ID`** / upload settings as CI. Typical outputs:
+
+**Android**
+
+```bash
+npx react-native bundle \
+  --platform android \
+  --dev false \
+  --minify true \
+  --entry-file index.js \
+  --bundle-output dist/android-release/index.android.bundle \
+  --sourcemap-output dist/android-release/index.android.bundle.map \
+  --assets-dest dist/android-release/res
+```
+
+**iOS** — set **`sourceMapFile`** to **`main.jsbundle`** for this invocation (here via env) so the map’s **`file`** field matches iOS Hermes stacks and **`releaseBundleFilename`**:
+
+```bash
+FARO_PLATFORM=ios npx react-native bundle \
+  --platform ios \
+  --dev false \
+  --minify true \
+  --entry-file index.js \
+  --bundle-output dist/ios-release/main.jsbundle \
+  --sourcemap-output dist/ios-release/main.jsbundle.map \
+  --assets-dest dist/ios-release/assets
+```
+
+**Verify:** preamble at the top of the `.jsbundle` / `.bundle` sets **`__faroBundleId_<appName>`**; the **`.map`** parses as JSON with **`version` 3**, non-empty **`sources`**, and **`file`** equal to the bundle basename you configured (`index.android.bundle` vs `main.jsbundle`).
+
+## Grafana UI
+
+In **Frontend Observability → your app → Settings**, use the **Source Maps** tab for `endpoint`, `appId`, `stackId`, and install snippets (Metro is included for mobile apps).

--- a/packages/faro-metro-plugin/android/source-map-upload.gradle
+++ b/packages/faro-metro-plugin/android/source-map-upload.gradle
@@ -1,0 +1,138 @@
+/**
+ * @grafana/faro-metro-plugin — composed source map upload hook for React Native (Hermes).
+ *
+ * ⚠️ FALLBACK / ADVANCED PATH ⚠️
+ *
+ * If your app installs `@grafana/faro-react-native` (the recommended setup),
+ * the same hook is already wired automatically via React Native autolinking
+ * from `node_modules/@grafana/faro-react-native/android/build.gradle` — you do
+ * NOT need to apply this file and you should NOT add anything to your
+ * `android/app/build.gradle` for source-map upload.
+ *
+ * Use this file only if:
+ *   - You use `@grafana/faro-metro-plugin` without `@grafana/faro-react-native`, or
+ *   - You have a custom Android setup that disables autolinking for the SDK.
+ *
+ * Then, in your app's `android/app/build.gradle`, add:
+ *
+ *   apply from: file("../../node_modules/@grafana/faro-metro-plugin/android/source-map-upload.gradle")
+ *
+ * After that, no other Android-side configuration is required. Any Gradle task that
+ * triggers `:app:bundleReleaseJsAndAssets` (for example `installRelease`,
+ * `assembleRelease`, `bundleRelease`, or `react-native run-android --mode=release`)
+ * will:
+ *
+ *   1. Run Metro (`@grafana/faro-metro-plugin` skips its own upload in this mode).
+ *   2. Run `hermesc` and `compose-source-maps.js` → produces the composed map at
+ *      `app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
+ *   3. Finalise the bundle task with:
+ *        node node_modules/@grafana/faro-metro-plugin/bin/faro-upload-source-map.js \
+ *          --verbose \
+ *          --map        <composed map path> \
+ *          --endpoint   "$FARO_SOURCEMAP_ENDPOINT" \
+ *          --app-id     "$FARO_SOURCEMAP_APP_ID" \
+ *          --stack-id   "$FARO_SOURCEMAP_STACK_ID" \
+ *          --api-key    "$FARO_SOURCEMAP_API_KEY" \
+ *          --bundle-id  "$FARO_BUNDLE_ID"
+ *      The shim at `bin/faro-upload-source-map.js` forwards the call to
+ *      `faro-cli metro upload`. Gradle reads every required setting from env
+ *      vars and passes them as **explicit CLI arguments**, so the CLI never
+ *      relies on its own env-var resolution from this entry point.
+ *
+ * Required env at build time (Gradle forwards each as a CLI flag):
+ *   FARO_BUNDLE_ID                — same id baked into the JS bundle preamble
+ *                                   (see `metro.config.js`); ensures
+ *                                   `meta.app.bundleId` on the device matches
+ *                                   the uploaded map. Forwarded as --bundle-id.
+ *   FARO_SOURCEMAP_ENDPOINT       — Forwarded as --endpoint.
+ *   FARO_SOURCEMAP_APP_ID         — Forwarded as --app-id.
+ *   FARO_SOURCEMAP_STACK_ID       — Forwarded as --stack-id.
+ *   FARO_SOURCEMAP_API_KEY        — Forwarded as --api-key.
+ *
+ * Optional env at build time:
+ *   FARO_SKIP_SOURCEMAP_UPLOAD=1  — skip the upload (e.g. for offline iteration).
+ *
+ * Why this is a top-level registration:
+ *   Gradle forbids registering new tasks inside `tasks.matching { ... }.configureEach`
+ *   blocks (you'll see a `DefaultTaskContainer#register on task set cannot be executed
+ *   in the current context` error). Registering at the top level and wiring
+ *   `finalizedBy` from `afterEvaluate` is the safe pattern.
+ */
+
+ext.faroComposedAndroidMap = file("$projectDir/build/generated/sourcemaps/react/release/index.android.bundle.map")
+ext.faroAndroidUploadCli = file("$projectDir/../../node_modules/@grafana/faro-metro-plugin/bin/faro-upload-source-map.js")
+ext.faroAndroidJsRoot = file("$projectDir/../..")
+
+def faroUploadComposedSourceMap = tasks.register("faroUploadComposedSourceMapAndroidRelease", Exec) {
+    group = "react"
+    description = "Upload the composed Hermes Android source map to Faro."
+
+    def composedMap = project.ext.faroComposedAndroidMap
+    def cliPath = project.ext.faroAndroidUploadCli
+    def jsRoot = project.ext.faroAndroidJsRoot
+
+    workingDir = jsRoot
+
+    def faroSkip = (System.getenv("FARO_SKIP_SOURCEMAP_UPLOAD") ?: "").trim().toLowerCase()
+    def faroBundleId = (System.getenv("FARO_BUNDLE_ID") ?: "").trim()
+    def faroEndpoint = (System.getenv("FARO_SOURCEMAP_ENDPOINT") ?: "").trim()
+    def faroAppId = (System.getenv("FARO_SOURCEMAP_APP_ID") ?: "").trim()
+    def faroStackId = (System.getenv("FARO_SOURCEMAP_STACK_ID") ?: "").trim()
+    def faroApiKey = (System.getenv("FARO_SOURCEMAP_API_KEY") ?: "").trim()
+
+    // Capture the inputs we use for caching / up-to-date checks. We
+    // deliberately *don't* track FARO_SOURCEMAP_API_KEY in inputs to avoid
+    // Gradle leaking it into a cache-key string.
+    inputs.file(composedMap).withPropertyName("composedMap").optional()
+    inputs.property("faroBundleId", faroBundleId)
+    inputs.property("faroEndpoint", faroEndpoint)
+    inputs.property("faroAppId", faroAppId)
+    inputs.property("faroStackId", faroStackId)
+    inputs.property("faroSkipUpload", faroSkip)
+
+    onlyIf {
+        if (faroSkip == "1" || faroSkip == "true") {
+            logger.lifecycle("[Faro] Skipping composed source map upload (FARO_SKIP_SOURCEMAP_UPLOAD=${faroSkip}).")
+            return false
+        }
+        if (!cliPath.exists()) {
+            logger.warn("[Faro] Skipping composed source map upload — CLI shim not found at ${cliPath}. Run `yarn install` after upgrading @grafana/faro-metro-plugin.")
+            return false
+        }
+        if (!composedMap.exists()) {
+            logger.warn("[Faro] Skipping composed source map upload — ${composedMap} does not exist. Did Hermes precompile run?")
+            return false
+        }
+        def missing = []
+        if (faroBundleId.isEmpty()) missing << "FARO_BUNDLE_ID"
+        if (faroEndpoint.isEmpty()) missing << "FARO_SOURCEMAP_ENDPOINT"
+        if (faroAppId.isEmpty()) missing << "FARO_SOURCEMAP_APP_ID"
+        if (faroStackId.isEmpty()) missing << "FARO_SOURCEMAP_STACK_ID"
+        if (faroApiKey.isEmpty()) missing << "FARO_SOURCEMAP_API_KEY"
+        if (!missing.isEmpty()) {
+            logger.warn("[Faro] Skipping composed source map upload — missing required env vars: ${missing.join(", ")}. Export them before running `yarn android --mode=release`. FARO_BUNDLE_ID must match the id baked into the bundle preamble by @grafana/faro-metro-plugin.")
+            return false
+        }
+        return true
+    }
+
+    commandLine(
+        "node", cliPath.absolutePath,
+        "--verbose",
+        "--map", composedMap.absolutePath,
+        "--endpoint", faroEndpoint,
+        "--app-id", faroAppId,
+        "--stack-id", faroStackId,
+        "--api-key", faroApiKey,
+        "--bundle-id", faroBundleId,
+    )
+}
+
+afterEvaluate {
+    ["bundleReleaseJsAndAssets", "createBundleReleaseJsAndAssets"].each { name ->
+        def bundleTask = tasks.findByName(name)
+        if (bundleTask != null) {
+            bundleTask.finalizedBy(faroUploadComposedSourceMap)
+        }
+    }
+}

--- a/packages/faro-metro-plugin/bin/faro-upload-source-map.js
+++ b/packages/faro-metro-plugin/bin/faro-upload-source-map.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * `faro-upload-source-map` binary for `@grafana/faro-metro-plugin`.
+ *
+ * Forwards every CLI argument verbatim to `faro-cli metro upload` by
+ * spawning Node on `@grafana/faro-cli`'s `cli.js`, then exits with the
+ * child process's status code. Intended for callers that resolve binaries
+ * by package name, e.g.:
+ *
+ *   npx --package @grafana/faro-metro-plugin faro-upload-source-map --map …
+ *
+ * For direct manual invocation, call `npx faro-cli metro upload …`.
+ */
+
+'use strict';
+
+const { spawnSync } = require('child_process');
+const cliPath = require.resolve('@grafana/faro-cli/dist/cjs/cli.js');
+const result = spawnSync('node', [cliPath, 'metro', 'upload', ...process.argv.slice(2)], {
+  stdio: 'inherit',
+});
+process.exit(result.status ?? 1);

--- a/packages/faro-metro-plugin/jest.config.js
+++ b/packages/faro-metro-plugin/jest.config.js
@@ -6,6 +6,8 @@ module.exports = {
   moduleFileExtensions: ['ts', 'js', 'json'],
   transform: {
     '^.+\\.ts$': ['ts-jest', {
+      // module=Node18 allows `import.meta` in source (used by metroDeps.ts for ESM-safe
+      // createRequire); ts-jest still emits CJS-compatible output via the useESM=false default.
       tsconfig: {
         module: 'CommonJS',
         moduleResolution: 'node',

--- a/packages/faro-metro-plugin/jest.config.js
+++ b/packages/faro-metro-plugin/jest.config.js
@@ -1,0 +1,17 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/test/*.test.ts'],
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      tsconfig: {
+        module: 'CommonJS',
+        moduleResolution: 'node',
+        esModuleInterop: true,
+        sourceMap: true,
+      },
+    }],
+  },
+};

--- a/packages/faro-metro-plugin/package.json
+++ b/packages/faro-metro-plugin/package.json
@@ -5,6 +5,9 @@
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",
   "module": "dist/esm/index.mjs",
+  "bin": {
+    "faro-upload-source-map": "bin/faro-upload-source-map.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/grafana/faro-javascript-bundler-plugins",
@@ -18,6 +21,7 @@
   },
   "dependencies": {
     "@grafana/faro-bundlers-shared": "^0.10.0",
+    "@grafana/faro-cli": "^0.10.0",
     "cross-fetch": "^4.0.0",
     "source-map": "^0.7.4"
   },
@@ -39,6 +43,8 @@
     "metro": ">=0.81.0"
   },
   "files": [
+    "android",
+    "bin",
     "dist",
     "README.md",
     "CHANGELOG.md",

--- a/packages/faro-metro-plugin/package.json
+++ b/packages/faro-metro-plugin/package.json
@@ -26,7 +26,7 @@
     "source-map": "^0.7.4"
   },
   "devDependencies": {
-    "@jest/globals": "30.3.0",
+    "@jest/globals": "30.4.1",
     "@rollup/plugin-babel": "6.1.0",
     "@rollup/plugin-commonjs": "29.0.2",
     "@rollup/plugin-json": "6.1.0",
@@ -34,7 +34,7 @@
     "@rollup/plugin-typescript": "11.1.6",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.2",
-    "jest": "30.3.0",
+    "jest": "30.4.1",
     "metro": "0.83.6",
     "ts-jest": "29.4.9",
     "tslib": "2.8.1"

--- a/packages/faro-metro-plugin/package.json
+++ b/packages/faro-metro-plugin/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@grafana/faro-metro-plugin",
+  "version": "0.1.0",
+  "description": "Upload React Native (Metro + Hermes) source maps to the Faro source map API and inject Faro bundle id preamble",
+  "main": "dist/cjs/index.js",
+  "types": "dist/cjs/index.d.ts",
+  "module": "dist/esm/index.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/grafana/faro-javascript-bundler-plugins",
+    "directory": "packages/faro-metro-plugin"
+  },
+  "license": "Apache-2.0",
+  "author": "Grafana Labs",
+  "scripts": {
+    "build": "rollup --config rollup.config.mjs",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@grafana/faro-bundlers-shared": "^0.10.0",
+    "cross-fetch": "^4.0.0",
+    "source-map": "^0.7.4"
+  },
+  "devDependencies": {
+    "@jest/globals": "30.3.0",
+    "@rollup/plugin-babel": "6.1.0",
+    "@rollup/plugin-commonjs": "29.0.2",
+    "@rollup/plugin-json": "6.1.0",
+    "@rollup/plugin-node-resolve": "16.0.3",
+    "@rollup/plugin-typescript": "11.1.6",
+    "@types/jest": "30.0.0",
+    "@types/node": "24.12.2",
+    "jest": "30.3.0",
+    "metro": "0.83.6",
+    "ts-jest": "29.4.9",
+    "tslib": "2.8.1"
+  },
+  "peerDependencies": {
+    "metro": ">=0.81.0"
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/faro-metro-plugin/rollup.config.mjs
+++ b/packages/faro-metro-plugin/rollup.config.mjs
@@ -1,0 +1,60 @@
+import babel from "@rollup/plugin-babel";
+import commonjs from "@rollup/plugin-commonjs";
+import json from "@rollup/plugin-json";
+import resolve from "@rollup/plugin-node-resolve";
+import typescript from "@rollup/plugin-typescript";
+import fs from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configPath = join(
+  dirname(fileURLToPath(import.meta.url)),
+  './package.json'
+);
+const packageJson = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+
+const extensions = [".ts"];
+
+export default {
+  input: "src/index.ts",
+  external: [
+    ...Object.keys(packageJson.dependencies),
+    "metro",
+  ],
+  output: [
+    {
+      file: packageJson.module,
+      format: "esm",
+      exports: "named",
+      sourcemap: true,
+    },
+    {
+      file: packageJson.main,
+      format: "cjs",
+      exports: "named",
+      sourcemap: true,
+    },
+  ],
+  plugins: [
+    typescript({
+      outDir: "dist",
+      exclude: ["**/*.test.ts", "**/test/**"],
+    }),
+    babel({
+      extensions,
+      babelHelpers: "bundled",
+      include: ["src/**/*"],
+      exclude: [/node_modules/, /test/, "*.test.ts"]
+    }),
+    json(),
+    resolve({
+      extensions,
+      rootDir: "./src",
+      preferBuiltins: true,
+    }),
+    commonjs({
+      include: /node_modules/,
+      exclude: ["**/*.test.ts", "**/test/**"]
+    }),
+  ],
+};

--- a/packages/faro-metro-plugin/src/envFlags.ts
+++ b/packages/faro-metro-plugin/src/envFlags.ts
@@ -1,0 +1,11 @@
+/**
+ * True for common env flag values: "1", "true" (case-insensitive, whitespace-trimmed).
+ * Used for example with `FARO_SKIP_SOURCEMAP_UPLOAD`.
+ */
+export function isTruthyEnvVar(value: string | undefined): boolean {
+  if (value == null) {
+    return false;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === '1' || normalized === 'true';
+}

--- a/packages/faro-metro-plugin/src/flattenMapForHermes.ts
+++ b/packages/faro-metro-plugin/src/flattenMapForHermes.ts
@@ -1,0 +1,118 @@
+import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
+
+/**
+ * Walk `s` once and build:
+ *   - `lineStartUtf16[i]`: UTF-16 code unit index of line (i+1)'s first character.
+ *   - `utf16ToUtf8[i]`: UTF-8 byte offset of the position that UTF-16 code unit `i` represents.
+ *
+ * Used to translate a Metro source map's `(generatedLine, generatedColumn)` — where
+ * columns are 0-based UTF-16 code unit indices per the source-map spec — into the
+ * UTF-8 byte offsets Hermes uses for stack frame columns. For an all-ASCII bundle the
+ * two tables collapse to a single line-start array; the bookkeeping only matters once
+ * the bundle contains non-Latin string literals, emoji, or other multi-byte content.
+ */
+function buildOffsetTables(s: string): { lineStartUtf16: number[]; utf16ToUtf8: number[] } {
+  const lineStartUtf16: number[] = [0];
+  const utf16ToUtf8: number[] = new Array(s.length + 1);
+  let utf8 = 0;
+  let i = 0;
+  while (i < s.length) {
+    utf16ToUtf8[i] = utf8;
+    const c = s.charCodeAt(i);
+    if (c === 0x0a) {
+      utf8 += 1;
+      i += 1;
+      lineStartUtf16.push(i);
+    } else if (c < 0x80) {
+      utf8 += 1;
+      i += 1;
+    } else if (c < 0x800) {
+      utf8 += 2;
+      i += 1;
+    } else if (c >= 0xd800 && c <= 0xdbff && i + 1 < s.length) {
+      // High surrogate paired with a following low surrogate encodes one Unicode
+      // codepoint in 4 UTF-8 bytes. Record the byte offset for the low surrogate's
+      // position too so columns landing on either half resolve identically.
+      utf16ToUtf8[i + 1] = utf8;
+      utf8 += 4;
+      i += 2;
+    } else {
+      utf8 += 3;
+      i += 1;
+    }
+  }
+  utf16ToUtf8[s.length] = utf8;
+  return { lineStartUtf16, utf16ToUtf8 };
+}
+
+/**
+ * Rewrite `mapJson` so every mapping is on generated line 1, with `column` set to the
+ * absolute UTF-8 byte offset of that mapping's position in `bundleCode`.
+ *
+ * Hermes stack frames are reported as `(line=1, column=<UTF-8 byte offset>)` regardless
+ * of newlines in the source. Standard Metro source maps key mappings by
+ * `(generatedLine, generatedColumn)` where line is newline-counted and column is a
+ * UTF-16 code unit index (per the source-map spec). Without this rewrite, a receiver
+ * looking up `(1, byteOffset)` against an un-flattened map misses everything past the
+ * first line; with non-ASCII content in the bundle, raw UTF-16 indices would also
+ * drift from Hermes' byte offsets.
+ *
+ * Assumes `mapJson` describes the original code Metro produced (pre-preamble) and
+ * `bundleCode` is the final bundle (`${preamble}\n${code}` as composed in
+ * `serialize.ts`). `preambleLines` is the number of bundle lines the preamble occupies
+ * before the original code starts — the default of 1 matches the snippet+newline
+ * pattern emitted by `createFaroMetroCustomSerializer`.
+ */
+export async function flattenMapForHermes(
+  mapJson: Record<string, unknown>,
+  bundleCode: string,
+  preambleLines = 1
+): Promise<Record<string, unknown>> {
+  const { lineStartUtf16, utf16ToUtf8 } = buildOffsetTables(bundleCode);
+
+  const asInput = mapJson as unknown as Parameters<typeof SourceMapConsumer.with>[0];
+
+  return SourceMapConsumer.with(asInput, null, async (consumer) => {
+    const generator = new SourceMapGenerator({
+      file: mapJson.file as string | undefined,
+      sourceRoot: mapJson.sourceRoot as string | undefined,
+    });
+
+    consumer.eachMapping((m) => {
+      if (m.source == null) {
+        return;
+      }
+      // Original code line L lives on bundle line L + preambleLines. `lineStartUtf16`
+      // is 0-indexed; the UTF-16 start of that bundle line is at index
+      // (preambleLines + L - 1). Clamp to the table to be defensive against malformed
+      // or trailing mappings that reference a line past the bundle's end.
+      const lineIdx = Math.min(preambleLines + m.generatedLine - 1, lineStartUtf16.length - 1);
+      const utf16Pos = Math.min(
+        lineStartUtf16[lineIdx] + m.generatedColumn,
+        utf16ToUtf8.length - 1
+      );
+      const absoluteCol = utf16ToUtf8[utf16Pos];
+      generator.addMapping({
+        generated: { line: 1, column: absoluteCol },
+        original: {
+          line: m.originalLine ?? 1,
+          column: m.originalColumn ?? 0,
+        },
+        source: m.source,
+        name: m.name ?? undefined,
+      });
+    });
+
+    for (const source of consumer.sources) {
+      // Pass `nullOnMissing=true` so sources without embedded content return `null`
+      // instead of throwing — Metro can emit maps with partial `sourcesContent`, and
+      // we want those to flatten without aborting.
+      const content = consumer.sourceContentFor(source, true);
+      if (content !== null) {
+        generator.setSourceContent(source, content);
+      }
+    }
+
+    return generator.toJSON() as unknown as Record<string, unknown>;
+  });
+}

--- a/packages/faro-metro-plugin/src/index.ts
+++ b/packages/faro-metro-plugin/src/index.ts
@@ -33,4 +33,5 @@ export default function withFaroConfig(
 
 export { createFaroMetroCustomSerializer, computeSkipUpload, getSortedModules } from './serialize';
 export { shiftGeneratedLineNumbers } from './shiftSourceMap';
+export { flattenMapForHermes } from './flattenMapForHermes';
 export { normalizeBundleIdLength, resolveBundleId } from './resolveBundleId';

--- a/packages/faro-metro-plugin/src/index.ts
+++ b/packages/faro-metro-plugin/src/index.ts
@@ -1,0 +1,36 @@
+import {
+  createFaroMetroCustomSerializer,
+  type FaroMetroPluginOptions,
+  type MetroCustomSerializer,
+} from './serialize';
+
+export type { FaroMetroPluginOptions, MetroCustomSerializer };
+
+/**
+ * Wraps a Metro config to inject the Faro bundle id preamble, adjust source maps, and (for release bundles) upload the JS source map to the Grafana KWL source map API.
+ *
+ * When using `@sentry/react-native` Metro integration, apply **Sentry outside** and **Faro inside** so the preamble stays at the start of the bundle, for example:
+ * `mergeConfig(getDefaultConfig(__dirname), withSentryConfig(withFaroConfig({}, faroOpts)))` — consult the Sentry and RN docs for your versions.
+ */
+export default function withFaroConfig(
+  metroConfig: Record<string, unknown>,
+  faroOptions: FaroMetroPluginOptions
+): Record<string, unknown> {
+  const serializer = metroConfig.serializer as Record<string, unknown> | undefined;
+  const previous = serializer?.customSerializer as MetroCustomSerializer | undefined;
+
+  return {
+    ...metroConfig,
+    serializer: {
+      ...serializer,
+      customSerializer: createFaroMetroCustomSerializer(
+        previous ?? null,
+        faroOptions
+      ),
+    },
+  };
+}
+
+export { createFaroMetroCustomSerializer, computeSkipUpload, getSortedModules } from './serialize';
+export { shiftGeneratedLineNumbers } from './shiftSourceMap';
+export { normalizeBundleIdLength, resolveBundleId } from './resolveBundleId';

--- a/packages/faro-metro-plugin/src/index.ts
+++ b/packages/faro-metro-plugin/src/index.ts
@@ -7,7 +7,9 @@ import {
 export type { FaroMetroPluginOptions, MetroCustomSerializer };
 
 /**
- * Wraps a Metro config to inject the Faro bundle id preamble, adjust source maps, and (for release bundles) upload the JS source map to the Grafana KWL source map API.
+ * Wraps a Metro config to inject the Faro bundle id preamble and adjust source maps for Hermes/JSC.
+ * Source map uploads run after `hermesc` + `compose-source-maps.js` via `faro-cli metro upload`
+ * or native hooks that invoke this package’s `bin/` scripts — not from Metro.
  *
  * When using `@sentry/react-native` Metro integration, apply **Sentry outside** and **Faro inside** so the preamble stays at the start of the bundle, for example:
  * `mergeConfig(getDefaultConfig(__dirname), withSentryConfig(withFaroConfig({}, faroOpts)))` — consult the Sentry and RN docs for your versions.
@@ -31,7 +33,12 @@ export default function withFaroConfig(
   };
 }
 
-export { createFaroMetroCustomSerializer, computeSkipUpload, getSortedModules } from './serialize';
+export {
+  createFaroMetroCustomSerializer,
+  computeSkipUpload,
+  detectHermesMode,
+  getSortedModules,
+} from './serialize';
 export { shiftGeneratedLineNumbers } from './shiftSourceMap';
 export { flattenMapForHermes } from './flattenMapForHermes';
 export { normalizeBundleIdLength, resolveBundleId } from './resolveBundleId';

--- a/packages/faro-metro-plugin/src/metroDeps.ts
+++ b/packages/faro-metro-plugin/src/metroDeps.ts
@@ -16,8 +16,17 @@ export function loadMetroDeps(): {
   ) => Promise<string>;
 } {
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
-    const metroPkg = require.resolve('metro/package.json') as string;
+    // ESM consumers don't have a global `require`; anchor createRequire to this
+    // module via __filename (CJS, including Jest's CJS test runtime) or
+    // import.meta.url (ESM build at runtime). Direct eval keeps `import.meta`
+    // out of the source AST so ts-jest's CJS compile stays happy — the eval
+    // branch only runs in ESM, where direct eval inherits the module scope
+    // and `import.meta` is syntactically valid.
+    // eslint-disable-next-line no-eval -- see comment above; rollup warns but the warning is informational.
+    const anchor: string =
+      typeof __filename === 'string' ? __filename : (eval('import.meta.url') as string);
+    const requireFromHere = createRequire(anchor);
+    const metroPkg = requireFromHere.resolve('metro/package.json');
     const requireMetro = createRequire(metroPkg);
     const metroRoot = path.dirname(metroPkg);
     const baseJSBundle = requireMetro(

--- a/packages/faro-metro-plugin/src/metroDeps.ts
+++ b/packages/faro-metro-plugin/src/metroDeps.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { createRequire } from 'module';
+
+/* Metro subpaths are not in package "exports"; load internals via absolute paths from the installed package root. */
+export function loadMetroDeps(): {
+  baseJSBundle: (
+    entryPoint: string,
+    prepend: readonly unknown[],
+    graph: Record<string, unknown>,
+    options: Record<string, unknown>
+  ) => unknown;
+  bundleToString: (bundle: unknown) => { code: string; metadata?: unknown };
+  sourceMapStringNonBlocking: (
+    modules: readonly unknown[],
+    options: Record<string, unknown>
+  ) => Promise<string>;
+} {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const metroPkg = require.resolve('metro/package.json') as string;
+    const requireMetro = createRequire(metroPkg);
+    const metroRoot = path.dirname(metroPkg);
+    const baseJSBundle = requireMetro(
+      path.join(metroRoot, 'src/DeltaBundler/Serializers/baseJSBundle.js')
+    ).default as (...args: unknown[]) => unknown;
+    const bundleToString = requireMetro(path.join(metroRoot, 'src/lib/bundleToString.js'))
+      .default as (b: unknown) => { code: string };
+    const sourceMapStringNonBlocking = requireMetro(
+      path.join(metroRoot, 'src/DeltaBundler/Serializers/sourceMapString.js')
+    ).sourceMapStringNonBlocking as (
+      modules: readonly unknown[],
+      options: Record<string, unknown>
+    ) => Promise<string>;
+
+    return { baseJSBundle, bundleToString, sourceMapStringNonBlocking };
+  } catch {
+    throw new Error(
+      'Cannot load Metro internals. Add `metro` (see peer dependency of @grafana/faro-metro-plugin).'
+    );
+  }
+}

--- a/packages/faro-metro-plugin/src/resolveBundleId.ts
+++ b/packages/faro-metro-plugin/src/resolveBundleId.ts
@@ -1,0 +1,29 @@
+import crypto from 'crypto';
+import { randomString, consoleInfoOrange } from '@grafana/faro-bundlers-shared';
+
+const MAX_BUNDLE_ID_LEN = 512;
+
+export function normalizeBundleIdLength(id: string): string {
+  if (id.length <= MAX_BUNDLE_ID_LEN) {
+    return id;
+  }
+  return crypto.createHash('sha256').update(id, 'utf8').digest('hex').slice(0, 32);
+}
+
+export function resolveBundleId(
+  explicitFromOptions: string | undefined,
+  bundleDev: boolean,
+  skipUpload: boolean
+): string {
+  const explicit = explicitFromOptions ?? process.env.FARO_BUNDLE_ID;
+  if (explicit) {
+    return normalizeBundleIdLength(explicit);
+  }
+  if (bundleDev || skipUpload) {
+    return normalizeBundleIdLength(`dev-${randomString(6)}`);
+  }
+  consoleInfoOrange(
+    'FARO_BUNDLE_ID is not set; using an ephemeral id for this build. Set FARO_BUNDLE_ID so uploads match meta.app.bundleId.'
+  );
+  return normalizeBundleIdLength(String(Date.now()) + randomString(5));
+}

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -1,15 +1,5 @@
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
 import {
   faroBundleIdSnippet,
-  consoleInfoOrange,
-  uploadCompressedSourceMaps,
-  uploadSourceMap,
-  THIRTY_MB_IN_BYTES,
-  ensureSourceMapFileProperty,
-  modifySourceMapFileProperty,
-  shouldProcessFile,
   isTruthyEnvVar,
   type FaroSourceMapUploaderPluginOptions,
 } from '@grafana/faro-bundlers-shared';
@@ -37,6 +27,53 @@ export type FaroMetroPluginOptions = FaroSourceMapUploaderPluginOptions & {
    */
   hermes?: boolean;
 };
+
+/**
+ * Internal description of how this Metro invocation should treat the source map.
+ *
+ * `precompiled` means a downstream Hermes step will run after Metro and produce the
+ * final composed map (Android/iOS release builds via Gradle/Xcode). In that case we
+ * MUST keep the packager map in its multi-line shape so `compose-source-maps.js` can
+ * consume it. Upload that composed map after the native build (`faro-upload-source-map`
+ * shim → `faro-cli metro upload`, or the Gradle/Xcode hooks).
+ *
+ * `runtime` means Hermes runs as an interpreter on the JS bundle (no precompile, e.g.
+ * dev mode or non-precompiled setups). Stack frames report `line=1, column=<byte>`
+ * so we flatten the map for Hermes bytecode symbolication upstream.
+ *
+ * `jsc` means classic JSC: standard `(line, col)` stacks, line-shift only.
+ */
+type HermesMode = 'precompiled' | 'runtime' | 'jsc';
+
+/**
+ * Autodetect how Metro is being invoked so the plugin produces the right map shape
+ * for Hermes precompile (`compose-source-maps.js`), Hermes interpreter, or JSC.
+ *
+ * Detection rules (most specific first):
+ *   - `pluginOptions.hermes === false` → `jsc`.
+ *   - `bundleOptions.dev === true` → `runtime` (dev server, Hermes interpreter).
+ *   - `FARO_DISABLE_HERMES_PRECOMPILE` truthy → `runtime` (escape hatch for users
+ *     who run Hermes without the precompile step in release).
+ *   - otherwise (`dev: false`, `hermes !== false`) → `precompiled`. This is the
+ *     default for `react-native run-android --variant=release` and Xcode "Release",
+ *     because the React Native Gradle/Xcode scripts run `hermesc` + `compose-source-maps.js`
+ *     after Metro.
+ */
+export function detectHermesMode(
+  pluginOptions: FaroMetroPluginOptions,
+  bundleOptions: Record<string, unknown>
+): HermesMode {
+  if (pluginOptions.hermes === false) {
+    return 'jsc';
+  }
+  if (Boolean(bundleOptions.dev)) {
+    return 'runtime';
+  }
+  if (isTruthyEnvVar(process.env.FARO_DISABLE_HERMES_PRECOMPILE)) {
+    return 'runtime';
+  }
+  return 'precompiled';
+}
 
 export type MetroCustomSerializer = (
   entryPoint: string,
@@ -113,85 +150,6 @@ async function toCodeAndMap(
   return raw;
 }
 
-async function maybeUploadMap(
-  mapJsonString: string,
-  bundleId: string,
-  pluginOptions: FaroMetroPluginOptions,
-  bundleDev: boolean
-): Promise<void> {
-  const skip = computeSkipUpload(pluginOptions);
-  if (skip || bundleDev) {
-    return;
-  }
-  const { apiKey } = pluginOptions;
-
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
-  const mapBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
-  const mapPath = path.join(tmpDir, `${mapBase}.map`);
-  try {
-    fs.writeFileSync(mapPath, mapJsonString, 'utf8');
-    ensureSourceMapFileProperty(mapPath, pluginOptions.verbose);
-    if (pluginOptions.prefixPath) {
-      modifySourceMapFileProperty(
-        mapPath,
-        pluginOptions.prefixPath,
-        pluginOptions.verbose,
-        pluginOptions.prefixPathBasenameOnly
-      );
-    }
-
-    const endpointBase = `${pluginOptions.endpoint.replace(/\/$/, '')}/app/${pluginOptions.appId}/sourcemaps/`;
-    const sourcemapEndpoint = `${endpointBase}${bundleId}`;
-    const gzipContents = pluginOptions.gzipContents !== false;
-    const keepSourcemaps = false;
-    const maxSize =
-      pluginOptions.maxUploadSize && pluginOptions.maxUploadSize > 0
-        ? pluginOptions.maxUploadSize
-        : THIRTY_MB_IN_BYTES;
-    const stats = fs.statSync(mapPath);
-    if (stats.size > maxSize) {
-      consoleInfoOrange(
-        `Source map exceeds maxUploadSize (${String(maxSize)} bytes); skipping upload`
-      );
-      return;
-    }
-
-    if (!shouldProcessFile(path.basename(mapPath), pluginOptions.outputFiles)) {
-      pluginOptions.verbose &&
-        consoleInfoOrange(
-          `Skipping source map upload: ${path.basename(mapPath)} does not match JS source map name pattern (e.g. *.js.map or *.bundle.map).`
-        );
-      return;
-    }
-
-    if (gzipContents) {
-      await uploadCompressedSourceMaps({
-        sourcemapEndpoint,
-        apiKey,
-        stackId: pluginOptions.stackId,
-        outputPath: tmpDir,
-        files: [mapPath],
-        keepSourcemaps,
-        verbose: pluginOptions.verbose,
-        proxy: pluginOptions.proxy,
-      });
-    } else {
-      await uploadSourceMap({
-        sourcemapEndpoint,
-        apiKey,
-        stackId: pluginOptions.stackId,
-        filePath: mapPath,
-        filename: path.basename(mapPath),
-        keepSourcemaps,
-        verbose: pluginOptions.verbose,
-        proxy: pluginOptions.proxy,
-      });
-    }
-  } finally {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
-  }
-}
-
 export function createFaroMetroCustomSerializer(
   previousSerializer: MetroCustomSerializer | null | undefined,
   pluginOptions: FaroMetroPluginOptions
@@ -216,19 +174,24 @@ export function createFaroMetroCustomSerializer(
     const newCode = `${snippet}\n${code}`;
 
     const mapObj = JSON.parse(map) as Record<string, unknown>;
-    const useHermes = pluginOptions.hermes !== false;
-    const rewritten = useHermes
-      ? await flattenMapForHermes(mapObj, newCode, 1)
-      : await shiftGeneratedLineNumbers(mapObj, 1);
+    const hermesMode = detectHermesMode(pluginOptions, bundleOptions);
+
+    // For `precompiled`, Gradle/Xcode runs `hermesc` + `compose-source-maps.js` after Metro.
+    // `compose-source-maps.js` walks the packager map per (line, col), so we MUST keep its
+    // multi-line shape — flattening here would wipe `sources` from the final composed map.
+    // For `runtime` (Hermes interpreter), stack frames are `(line=1, col=<byte>)` so we
+    // flatten. For `jsc`, classic line/col stacks need only the +1 line shift.
+    let rewritten: Record<string, unknown>;
+    if (hermesMode === 'runtime') {
+      rewritten = await flattenMapForHermes(mapObj, newCode, 1);
+    } else {
+      rewritten = await shiftGeneratedLineNumbers(mapObj, 1);
+    }
     const mapFileBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
     if (rewritten.file == null || rewritten.file === '') {
       rewritten.file = mapFileBase;
     }
     const mapOut = JSON.stringify(rewritten);
-
-    if (!skip && !bundleDev) {
-      await maybeUploadMap(mapOut, bundleId, pluginOptions, bundleDev);
-    }
 
     return { code: newCode, map: mapOut };
   };

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -14,6 +14,7 @@ import {
   type FaroSourceMapUploaderPluginOptions,
 } from '@grafana/faro-bundlers-shared';
 import { shiftGeneratedLineNumbers } from './shiftSourceMap';
+import { flattenMapForHermes } from './flattenMapForHermes';
 import { resolveBundleId } from './resolveBundleId';
 import { loadMetroDeps } from './metroDeps';
 
@@ -26,6 +27,15 @@ export type FaroMetroPluginOptions = FaroSourceMapUploaderPluginOptions & {
    * Defaults from the temporary map basename. Align with `releaseBundleFilename` in `@grafana/faro-react-native` if you change it.
    */
   sourceMapFile?: string;
+  /**
+   * Emit a Hermes-compatible "flat" source map where every mapping lives on generated
+   * line 1 with `column` set to the absolute byte offset in the JS bundle. Hermes stack
+   * frames always report `line=1, column=<byte offset>`, so a normal multi-line generated
+   * map can't be looked up by the receiver. Defaults to `true` (Hermes is the default
+   * runtime in modern React Native). Set `false` for JSC-only builds, which will fall
+   * back to the legacy `+1` line shift.
+   */
+  hermes?: boolean;
 };
 
 export type MetroCustomSerializer = (
@@ -206,12 +216,15 @@ export function createFaroMetroCustomSerializer(
     const newCode = `${snippet}\n${code}`;
 
     const mapObj = JSON.parse(map) as Record<string, unknown>;
-    const shifted = await shiftGeneratedLineNumbers(mapObj, 1);
+    const useHermes = pluginOptions.hermes !== false;
+    const rewritten = useHermes
+      ? await flattenMapForHermes(mapObj, newCode, 1)
+      : await shiftGeneratedLineNumbers(mapObj, 1);
     const mapFileBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
-    if (shifted.file == null || shifted.file === '') {
-      shifted.file = mapFileBase;
+    if (rewritten.file == null || rewritten.file === '') {
+      rewritten.file = mapFileBase;
     }
-    const mapOut = JSON.stringify(shifted);
+    const mapOut = JSON.stringify(rewritten);
 
     if (!skip && !bundleDev) {
       await maybeUploadMap(mapOut, bundleId, pluginOptions, bundleDev);

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -1,0 +1,222 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  faroBundleIdSnippet,
+  consoleInfoOrange,
+  uploadCompressedSourceMaps,
+  uploadSourceMap,
+  THIRTY_MB_IN_BYTES,
+  ensureSourceMapFileProperty,
+  modifySourceMapFileProperty,
+  shouldProcessFile,
+  isTruthyEnvVar,
+  type FaroSourceMapUploaderPluginOptions,
+} from '@grafana/faro-bundlers-shared';
+import { shiftGeneratedLineNumbers } from './shiftSourceMap';
+import { resolveBundleId } from './resolveBundleId';
+import { loadMetroDeps } from './metroDeps';
+
+/**
+ * Metro plugin options extend the shared Faro uploader options with Metro-specific fields.
+ */
+export type FaroMetroPluginOptions = FaroSourceMapUploaderPluginOptions & {
+  /**
+   * Base name of the generated bundle in the source map `file` field (e.g. `bundle.js`).
+   * Defaults from the temporary map basename. Align with `releaseBundleFilename` in `@grafana/faro-react-native` if you change it.
+   */
+  sourceMapFile?: string;
+};
+
+export type MetroCustomSerializer = (
+  entryPoint: string,
+  prepend: readonly unknown[],
+  graph: { dependencies: Map<string, { path: string }> },
+  bundleOptions: Record<string, unknown>
+) => Promise<string | { code: string; map: string }>;
+
+export function getSortedModules(
+  graph: { dependencies: Map<string, { path: string }> },
+  createModuleId: (modulePath: string) => number
+): { path: string }[] {
+  const modules = [...graph.dependencies.values()];
+  for (const m of modules) {
+    createModuleId(m.path);
+  }
+  return modules.sort((a, b) => createModuleId(a.path) - createModuleId(b.path));
+}
+
+export function computeSkipUpload(pluginOptions: FaroMetroPluginOptions): boolean {
+  if (isTruthyEnvVar(process.env.FARO_SKIP_SOURCEMAP_UPLOAD)) {
+    return true;
+  }
+  if (pluginOptions.skipUpload === true) {
+    return true;
+  }
+  if (pluginOptions.skipUpload === false) {
+    return false;
+  }
+  return process.env.NODE_ENV === 'development';
+}
+
+async function computeModuleSourceMap(
+  prepend: readonly unknown[],
+  graph: { dependencies: Map<string, { path: string }> },
+  bundleOptions: Record<string, unknown>
+): Promise<string> {
+  const { sourceMapStringNonBlocking } = loadMetroDeps();
+  const createModuleId = bundleOptions.createModuleId as (modulePath: string) => number;
+  return sourceMapStringNonBlocking(
+    [...prepend, ...getSortedModules(graph, createModuleId)],
+    {
+      excludeSource: false,
+      processModuleFilter: bundleOptions.processModuleFilter as (m: unknown) => boolean,
+      shouldAddToIgnoreList: bundleOptions.shouldAddToIgnoreList as (m: unknown) => boolean,
+      getSourceUrl: bundleOptions.getSourceUrl as (m: unknown) => string,
+    }
+  );
+}
+
+async function runDefaultMetroSerialize(
+  entryPoint: string,
+  prepend: readonly unknown[],
+  graph: { dependencies: Map<string, { path: string }> },
+  bundleOptions: Record<string, unknown>
+): Promise<{ code: string; map: string }> {
+  const { baseJSBundle, bundleToString } = loadMetroDeps();
+  const bundle = baseJSBundle(entryPoint, prepend, graph, bundleOptions);
+  const { code } = bundleToString(bundle);
+  const map = await computeModuleSourceMap(prepend, graph, bundleOptions);
+  return { code, map };
+}
+
+async function toCodeAndMap(
+  raw: string | { code: string; map: string },
+  prepend: readonly unknown[],
+  graph: { dependencies: Map<string, { path: string }> },
+  bundleOptions: Record<string, unknown>
+): Promise<{ code: string; map: string }> {
+  if (typeof raw === 'string') {
+    const map = await computeModuleSourceMap(prepend, graph, bundleOptions);
+    return { code: raw, map };
+  }
+  return raw;
+}
+
+async function maybeUploadMap(
+  mapJsonString: string,
+  bundleId: string,
+  pluginOptions: FaroMetroPluginOptions,
+  bundleDev: boolean
+): Promise<void> {
+  const skip = computeSkipUpload(pluginOptions);
+  if (skip || bundleDev) {
+    return;
+  }
+  const { apiKey } = pluginOptions;
+
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
+  const mapBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
+  const mapPath = path.join(tmpDir, `${mapBase}.map`);
+  try {
+    fs.writeFileSync(mapPath, mapJsonString, 'utf8');
+    ensureSourceMapFileProperty(mapPath, pluginOptions.verbose);
+    if (pluginOptions.prefixPath) {
+      modifySourceMapFileProperty(
+        mapPath,
+        pluginOptions.prefixPath,
+        pluginOptions.verbose,
+        pluginOptions.prefixPathBasenameOnly
+      );
+    }
+
+    const endpointBase = `${pluginOptions.endpoint.replace(/\/$/, '')}/app/${pluginOptions.appId}/sourcemaps/`;
+    const sourcemapEndpoint = `${endpointBase}${bundleId}`;
+    const gzipContents = pluginOptions.gzipContents !== false;
+    const keepSourcemaps = false;
+    const maxSize =
+      pluginOptions.maxUploadSize && pluginOptions.maxUploadSize > 0
+        ? pluginOptions.maxUploadSize
+        : THIRTY_MB_IN_BYTES;
+    const stats = fs.statSync(mapPath);
+    if (stats.size > maxSize) {
+      consoleInfoOrange(
+        `Source map exceeds maxUploadSize (${String(maxSize)} bytes); skipping upload`
+      );
+      return;
+    }
+
+    if (!shouldProcessFile(path.basename(mapPath), pluginOptions.outputFiles)) {
+      pluginOptions.verbose &&
+        consoleInfoOrange(
+          `Skipping source map upload: ${path.basename(mapPath)} does not match JS source map name pattern (e.g. *.js.map or *.bundle.map).`
+        );
+      return;
+    }
+
+    if (gzipContents) {
+      await uploadCompressedSourceMaps({
+        sourcemapEndpoint,
+        apiKey,
+        stackId: pluginOptions.stackId,
+        outputPath: tmpDir,
+        files: [mapPath],
+        keepSourcemaps,
+        verbose: pluginOptions.verbose,
+        proxy: pluginOptions.proxy,
+      });
+    } else {
+      await uploadSourceMap({
+        sourcemapEndpoint,
+        apiKey,
+        stackId: pluginOptions.stackId,
+        filePath: mapPath,
+        filename: path.basename(mapPath),
+        keepSourcemaps,
+        verbose: pluginOptions.verbose,
+        proxy: pluginOptions.proxy,
+      });
+    }
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+export function createFaroMetroCustomSerializer(
+  previousSerializer: MetroCustomSerializer | null | undefined,
+  pluginOptions: FaroMetroPluginOptions
+): (
+  entryPoint: string,
+  prepend: readonly unknown[],
+  graph: { dependencies: Map<string, { path: string }> },
+  bundleOptions: Record<string, unknown>
+) => Promise<{ code: string; map: string }> {
+  return async (entryPoint, prepend, graph, bundleOptions) => {
+    const bundleDev = Boolean(bundleOptions.dev);
+    const skip = computeSkipUpload(pluginOptions);
+
+    const inner = previousSerializer
+      ? await previousSerializer(entryPoint, prepend, graph, bundleOptions)
+      : await runDefaultMetroSerialize(entryPoint, prepend, graph, bundleOptions);
+
+    const { code, map } = await toCodeAndMap(inner, prepend, graph, bundleOptions);
+
+    const bundleId = resolveBundleId(pluginOptions.bundleId, bundleDev, skip);
+    const snippet = faroBundleIdSnippet(bundleId, pluginOptions.appName);
+    const newCode = `${snippet}\n${code}`;
+
+    const mapObj = JSON.parse(map) as Record<string, unknown>;
+    const shifted = await shiftGeneratedLineNumbers(mapObj, 1);
+    const mapFileBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
+    if (shifted.file == null || shifted.file === '') {
+      shifted.file = mapFileBase;
+    }
+    const mapOut = JSON.stringify(shifted);
+
+    if (!skip && !bundleDev) {
+      await maybeUploadMap(mapOut, bundleId, pluginOptions, bundleDev);
+    }
+
+    return { code: newCode, map: mapOut };
+  };
+}

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -1,12 +1,12 @@
 import {
   faroBundleIdSnippet,
-  isTruthyEnvVar,
   type FaroSourceMapUploaderPluginOptions,
 } from '@grafana/faro-bundlers-shared';
 import { shiftGeneratedLineNumbers } from './shiftSourceMap';
 import { flattenMapForHermes } from './flattenMapForHermes';
 import { resolveBundleId } from './resolveBundleId';
 import { loadMetroDeps } from './metroDeps';
+import { isTruthyEnvVar } from './envFlags';
 
 /**
  * Metro plugin options extend the shared Faro uploader options with Metro-specific fields.

--- a/packages/faro-metro-plugin/src/shiftSourceMap.ts
+++ b/packages/faro-metro-plugin/src/shiftSourceMap.ts
@@ -36,7 +36,7 @@ export async function shiftGeneratedLineNumbers(
     });
 
     for (const source of consumer.sources) {
-      const content = consumer.sourceContentFor(source);
+      const content = consumer.sourceContentFor(source, /* nullOnMissing */ true);
       if (content !== null) {
         generator.setSourceContent(source, content);
       }

--- a/packages/faro-metro-plugin/src/shiftSourceMap.ts
+++ b/packages/faro-metro-plugin/src/shiftSourceMap.ts
@@ -1,0 +1,47 @@
+import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
+
+/** Shifts all generated line numbers in `mapJson` by `lineOffset` (for prepended preamble lines). */
+export async function shiftGeneratedLineNumbers(
+  mapJson: Record<string, unknown>,
+  lineOffset: number
+): Promise<Record<string, unknown>> {
+  if (lineOffset === 0) {
+    return mapJson;
+  }
+
+  const asInput = mapJson as unknown as Parameters<typeof SourceMapConsumer.with>[0];
+
+  return SourceMapConsumer.with(asInput, null, async (consumer) => {
+    const generator = new SourceMapGenerator({
+      file: mapJson.file as string | undefined,
+      sourceRoot: mapJson.sourceRoot as string | undefined,
+    });
+
+    consumer.eachMapping((m) => {
+      if (m.source == null) {
+        return;
+      }
+      generator.addMapping({
+        generated: {
+          line: m.generatedLine + lineOffset,
+          column: m.generatedColumn,
+        },
+        original: {
+          line: m.originalLine ?? 1,
+          column: m.originalColumn ?? 0,
+        },
+        source: m.source,
+        name: m.name ?? undefined,
+      });
+    });
+
+    for (const source of consumer.sources) {
+      const content = consumer.sourceContentFor(source);
+      if (content !== null) {
+        generator.setSourceContent(source, content);
+      }
+    }
+
+    return generator.toJSON() as unknown as Record<string, unknown>;
+  });
+}

--- a/packages/faro-metro-plugin/src/test/detectHermesMode.test.ts
+++ b/packages/faro-metro-plugin/src/test/detectHermesMode.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test, beforeEach, afterEach } from '@jest/globals';
+import { createFaroMetroCustomSerializer, detectHermesMode } from '../index';
+
+const baseBundleOptions = () => {
+  const ids = new Map<string, number>();
+  let n = 1;
+  const createModuleId = (p: string) => {
+    if (!ids.has(p)) ids.set(p, n++);
+    return ids.get(p)!;
+  };
+  return {
+    asyncRequireModulePath: '',
+    processModuleFilter: () => true,
+    createModuleId,
+    getRunModuleStatement: (_moduleId: string) => `__r(${_moduleId});`,
+    globalPrefix: '',
+    dev: false,
+    includeAsyncPaths: false,
+    projectRoot: '/app',
+    modulesOnly: false,
+    runBeforeMainModule: [] as string[],
+    runModule: true,
+    sourceMapUrl: 'index.bundle.map',
+    sourceUrl: '',
+    inlineSourceMap: false,
+    serverRoot: '/app',
+    shouldAddToIgnoreList: () => false,
+    getSourceUrl: () => '',
+  };
+};
+
+const baseFaroOpts = () => ({
+  appName: 'rn-app',
+  endpoint: 'http://localhost:8000/api/v1',
+  appId: '1',
+  stackId: 'stack',
+  apiKey: 'key',
+});
+
+describe('detectHermesMode', () => {
+  afterEach(() => {
+    delete process.env.FARO_DISABLE_HERMES_PRECOMPILE;
+  });
+
+  test('release build (dev: false) with default options is "precompiled"', () => {
+    expect(detectHermesMode(baseFaroOpts(), baseBundleOptions())).toBe('precompiled');
+  });
+
+  test('dev build (dev: true) is "runtime" (Hermes interpreter)', () => {
+    const opts = { ...baseBundleOptions(), dev: true };
+    expect(detectHermesMode(baseFaroOpts(), opts)).toBe('runtime');
+  });
+
+  test('hermes: false forces "jsc" even on release', () => {
+    const faro = { ...baseFaroOpts(), hermes: false };
+    expect(detectHermesMode(faro, baseBundleOptions())).toBe('jsc');
+  });
+
+  test('FARO_DISABLE_HERMES_PRECOMPILE=true downgrades release to "runtime"', () => {
+    process.env.FARO_DISABLE_HERMES_PRECOMPILE = 'true';
+    expect(detectHermesMode(baseFaroOpts(), baseBundleOptions())).toBe('runtime');
+  });
+
+  test('FARO_DISABLE_HERMES_PRECOMPILE=1 also recognized', () => {
+    process.env.FARO_DISABLE_HERMES_PRECOMPILE = '1';
+    expect(detectHermesMode(baseFaroOpts(), baseBundleOptions())).toBe('runtime');
+  });
+
+  test('hermes: false beats FARO_DISABLE_HERMES_PRECOMPILE (explicit option wins)', () => {
+    process.env.FARO_DISABLE_HERMES_PRECOMPILE = 'true';
+    const faro = { ...baseFaroOpts(), hermes: false };
+    expect(detectHermesMode(faro, baseBundleOptions())).toBe('jsc');
+  });
+});
+
+describe('serializer behaviour by Hermes mode', () => {
+  let prevNodeEnv: string | undefined;
+  beforeEach(() => {
+    prevNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    process.env.FARO_BUNDLE_ID = 'unit-test-id';
+  });
+
+  afterEach(() => {
+    if (prevNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = prevNodeEnv;
+    }
+    delete process.env.FARO_BUNDLE_ID;
+    delete process.env.FARO_DISABLE_HERMES_PRECOMPILE;
+  });
+
+  test('precompiled (release default): emits valid map', async () => {
+    const serializer = createFaroMetroCustomSerializer(null, baseFaroOpts());
+    const out = await serializer(
+      '/app/index.js',
+      [],
+      { dependencies: new Map() },
+      baseBundleOptions()
+    );
+
+    const map = JSON.parse(out.map) as { mappings: string; version: number };
+    expect(typeof map.mappings).toBe('string');
+    expect(map.version).toBe(3);
+  });
+
+  test('runtime (dev build): map flattened path, dev bundle id', async () => {
+    delete process.env.FARO_BUNDLE_ID;
+    const serializer = createFaroMetroCustomSerializer(null, baseFaroOpts());
+    const out = await serializer(
+      '/app/index.js',
+      [],
+      { dependencies: new Map() },
+      { ...baseBundleOptions(), dev: true }
+    );
+
+    const map = JSON.parse(out.map) as { mappings: string; version: number };
+    expect(typeof map.mappings).toBe('string');
+    expect(map.version).toBe(3);
+    expect(out.code).toMatch(/dev-[a-f0-9]+/);
+  });
+
+  test('runtime (release + FARO_DISABLE_HERMES_PRECOMPILE=true): completes without Metro upload', async () => {
+    process.env.FARO_DISABLE_HERMES_PRECOMPILE = 'true';
+    const serializer = createFaroMetroCustomSerializer(null, baseFaroOpts());
+    const out = await serializer(
+      '/app/index.js',
+      [],
+      { dependencies: new Map() },
+      baseBundleOptions()
+    );
+    expect(out.code).toContain('"unit-test-id"');
+    expect(JSON.parse(out.map).version).toBe(3);
+  });
+
+  test('jsc (hermes: false): completes release serialization', async () => {
+    const serializer = createFaroMetroCustomSerializer(null, {
+      ...baseFaroOpts(),
+      hermes: false,
+    });
+    const out = await serializer(
+      '/app/index.js',
+      [],
+      { dependencies: new Map() },
+      baseBundleOptions()
+    );
+    expect(out.code).toContain('"unit-test-id"');
+    expect(JSON.parse(out.map).version).toBe(3);
+  });
+
+  test('skipUpload: true uses dev bundle id even when release + FARO_DISABLE_HERMES_PRECOMPILE', async () => {
+    delete process.env.FARO_BUNDLE_ID;
+    process.env.FARO_DISABLE_HERMES_PRECOMPILE = 'true';
+    const serializer = createFaroMetroCustomSerializer(null, {
+      ...baseFaroOpts(),
+      skipUpload: true,
+    });
+    const out = await serializer(
+      '/app/index.js',
+      [],
+      { dependencies: new Map() },
+      baseBundleOptions()
+    );
+    expect(out.code).toMatch(/dev-[a-f0-9]+/);
+  });
+});

--- a/packages/faro-metro-plugin/src/test/fixtures/path-a-release.index.android.bundle.map
+++ b/packages/faro-metro-plugin/src/test/fixtures/path-a-release.index.android.bundle.map
@@ -1,0 +1,8 @@
+{
+  "version": 3,
+  "sources": ["../../node_modules/metro-runtime/src/polyfills/require.js", "index.js"],
+  "file": "index.android.bundle",
+  "names": [],
+  "mappings": "AAAA",
+  "sourcesContent": [null, null]
+}

--- a/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
+++ b/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
@@ -1,0 +1,212 @@
+import { describe, test, expect } from '@jest/globals';
+import { SourceMapConsumer, SourceMapGenerator, type RawSourceMap } from 'source-map';
+import { flattenMapForHermes } from '../flattenMapForHermes';
+
+/**
+ * Build a tiny multi-line source map describing `code` and return the JSON form.
+ * Each mapping list element is `[genLine, genCol, source, origLine, origCol, name?]`.
+ */
+function makeMap(
+  file: string,
+  mappings: Array<[number, number, string, number, number, string?]>,
+  sourcesContent?: Record<string, string>
+): Record<string, unknown> {
+  const gen = new SourceMapGenerator({ file });
+  for (const [gl, gc, src, ol, oc, name] of mappings) {
+    gen.addMapping({
+      generated: { line: gl, column: gc },
+      original: { line: ol, column: oc },
+      source: src,
+      name,
+    });
+  }
+  if (sourcesContent) {
+    for (const [src, content] of Object.entries(sourcesContent)) {
+      gen.setSourceContent(src, content);
+    }
+  }
+  return JSON.parse(gen.toString()) as Record<string, unknown>;
+}
+
+describe('flattenMapForHermes', () => {
+  test('moves every mapping to generated line 1 with absolute byte offsets', async () => {
+    // Original code (what the map describes):
+    //   line 1: "AAAA"   (bytes 0..3)
+    //   line 2: "BBBB"   (bytes 5..8 after the \n at byte 4)
+    //   line 3: "CCCCCC" (bytes 10..15)
+    const map = makeMap('bundle.js', [
+      [1, 0, 'foo.ts', 10, 1],
+      [2, 4, 'foo.ts', 20, 2],
+      [3, 6, 'bar.ts', 30, 3],
+    ]);
+
+    // Final bundle = "PREAMBLE\n" (9 bytes, \n at byte 8) + original code.
+    // Original code line L starts at bundle byte:
+    //   L=1 → 9, L=2 → 14, L=3 → 19
+    const bundleCode = 'PREAMBLE\nAAAA\nBBBB\nCCCCCC';
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    // Result mappings must live on one line only (no `;` separators).
+    expect(flat.mappings).not.toContain(';');
+
+    // Verify each lookup resolves to the original source position.
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 9 })).toMatchObject({
+      source: 'foo.ts',
+      line: 10,
+      column: 1,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 18 })).toMatchObject({
+      source: 'foo.ts',
+      line: 20,
+      column: 2,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 25 })).toMatchObject({
+      source: 'bar.ts',
+      line: 30,
+      column: 3,
+    });
+  });
+
+  test('honours custom preambleLines for multi-line preambles', async () => {
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0],
+      [2, 2, 'a.ts', 2, 0],
+    ]);
+
+    // Two-line preamble: bundle line 3 (byte 6) is where original code line 1 starts.
+    //   "AB\nCD\n" → preamble; \n at bytes 2 and 5; line 3 starts at byte 6
+    //   "EE\nFF"  → original; line 1 starts at 6, line 2 starts at 9
+    const bundleCode = 'AB\nCD\nEE\nFF';
+    const flat = (await flattenMapForHermes(map, bundleCode, 2)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 6 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 11 })).toMatchObject({
+      source: 'a.ts',
+      line: 2,
+      column: 0,
+    });
+  });
+
+  test('preserves sourcesContent and file fields', async () => {
+    const map = makeMap(
+      'bundle.js',
+      [[1, 0, 'a.ts', 1, 0]],
+      { 'a.ts': 'export const x = 1;\n' }
+    );
+    const flat = (await flattenMapForHermes(map, '!\nAAAA', 1)) as unknown as RawSourceMap;
+
+    expect(flat.file).toBe('bundle.js');
+    expect(flat.sourcesContent).toEqual(['export const x = 1;\n']);
+  });
+
+  test('preserves mapping name field', async () => {
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 5, 4, 'myFn'],
+    ]);
+
+    const flat = (await flattenMapForHermes(map, 'X\nAAA', 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 2 })).toMatchObject({
+      source: 'a.ts',
+      line: 5,
+      column: 4,
+      name: 'myFn',
+    });
+  });
+
+  test('encodes non-ASCII bundle content as UTF-8 byte offsets', async () => {
+    // Original code (what the map describes):
+    //   line 1 in UTF-16: "ñAB"  (3 code units: ñ=1, A=1, B=1)
+    //   line 1 in UTF-8 : "ñAB"  (4 bytes:     ñ=2, A=1, B=1)
+    // Map mapping at (generatedLine=1, generatedColumn=1) sits **after** ñ.
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0], // before ñ
+      [1, 1, 'a.ts', 1, 5], // after ñ — UTF-16 col=1, UTF-8 byte offset relative to line start=2
+    ]);
+
+    // Final bundle = "X\n" (preamble, 2 UTF-8 bytes) + "ñAB" → 6 UTF-8 bytes total.
+    //   byte 0..0 = 'X', byte 1 = '\n', byte 2..3 = 'ñ', byte 4 = 'A', byte 5 = 'B'.
+    const bundleCode = 'X\nñAB';
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // mapping (1, 0) → bundle byte 2 (before ñ)
+    expect(consumer.originalPositionFor({ line: 1, column: 2 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    // mapping (1, 1) → bundle byte 4 (after ñ; would be byte 3 if we (wrongly) used UTF-16 cols)
+    expect(consumer.originalPositionFor({ line: 1, column: 4 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 5,
+    });
+  });
+
+  test('handles 4-byte UTF-8 sequences (surrogate pairs / emoji)', async () => {
+    // '🎉' (U+1F389) is a single Unicode codepoint encoded as a UTF-16 surrogate pair
+    // (2 code units) and 4 UTF-8 bytes. After it, an ASCII char should be at byte 4.
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0], // before emoji
+      [1, 2, 'a.ts', 1, 9], // after emoji — UTF-16 col=2 (past the surrogate pair), UTF-8 offset=4
+    ]);
+
+    const bundleCode = '\n🎉Z'; // preamble line 1 is empty, original code is line 2
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // Bundle byte layout: \n(1) + 🎉(4 bytes) + Z(1) → emoji starts at byte 1, Z at byte 5.
+    expect(consumer.originalPositionFor({ line: 1, column: 1 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 5 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 9,
+    });
+  });
+
+  test('tolerates sources without sourcesContent (does not throw)', async () => {
+    // Build a map with a `sources` entry that has NO sourcesContent. Without the
+    // `nullOnMissing` second arg, `SourceMapConsumer#sourceContentFor` would throw
+    // here and abort the entire flatten.
+    const gen = new SourceMapGenerator({ file: 'bundle.js' });
+    gen.addMapping({
+      generated: { line: 1, column: 0 },
+      original: { line: 1, column: 0 },
+      source: 'a.ts',
+    });
+    // Deliberately no `setSourceContent` call. SourceMapGenerator emits an empty
+    // `sourcesContent: []`, which the consumer treats as "missing for every source".
+    const map = JSON.parse(gen.toString()) as Record<string, unknown>;
+
+    await expect(flattenMapForHermes(map, 'X\nAAA', 1)).resolves.toBeDefined();
+  });
+
+  test('clamps when a mapping references a generated line past the bundle length', async () => {
+    // Map claims a mapping on generated line 5, but the bundle only has 3 lines.
+    // The function should clamp to the last known line rather than throw / corrupt.
+    const map = makeMap('bundle.js', [[5, 1, 'a.ts', 1, 0]]);
+    const bundleCode = 'X\nY\nZ'; // 3 lines, lineStart = [0, 2, 4]
+
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // Without throwing: clamped to the last line start (4) + col (1) = 5.
+    expect(consumer.originalPositionFor({ line: 1, column: 5 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+  });
+});

--- a/packages/faro-metro-plugin/src/test/index.test.ts
+++ b/packages/faro-metro-plugin/src/test/index.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, test, afterEach, beforeEach } from '@jest/globals';
-import { jest as jestGlobal } from '@jest/globals';
+import { describe, expect, test, afterEach } from '@jest/globals';
 import defaultWithFaroConfig, {
   createFaroMetroCustomSerializer,
   computeSkipUpload,
@@ -7,22 +6,6 @@ import defaultWithFaroConfig, {
   normalizeBundleIdLength,
   resolveBundleId,
 } from '../index';
-import {
-  uploadCompressedSourceMaps,
-  uploadSourceMap,
-} from '@grafana/faro-bundlers-shared';
-
-jestGlobal.mock('@grafana/faro-bundlers-shared', () => {
-  const actual = jestGlobal.requireActual('@grafana/faro-bundlers-shared') as Record<string, unknown>;
-  return {
-    ...actual,
-    uploadCompressedSourceMaps: jestGlobal.fn(),
-    uploadSourceMap: jestGlobal.fn(),
-  };
-});
-
-const mockUploadCompressed = jestGlobal.mocked(uploadCompressedSourceMaps);
-const mockUploadPlain = jestGlobal.mocked(uploadSourceMap);
 
 describe('@grafana/faro-metro-plugin', () => {
   test('withFaroConfig attaches customSerializer', () => {
@@ -141,8 +124,6 @@ describe('@grafana/faro-metro-plugin', () => {
     afterEach(() => {
       delete process.env.FARO_BUNDLE_ID;
       delete process.env.FARO_SKIP_SOURCEMAP_UPLOAD;
-      mockUploadCompressed.mockClear();
-      mockUploadPlain.mockClear();
     });
 
     test('prepends faro bundle id snippet (release bundle)', async () => {
@@ -176,130 +157,6 @@ describe('@grafana/faro-metro-plugin', () => {
       const opts = { ...baseOptions(), dev: true };
       const out = await serializer('/app/index.js', [], graph, opts);
       expect(out.code).toMatch(/dev-[a-f0-9]+/);
-    });
-
-    describe('release upload to source map API', () => {
-      let prevNodeEnv: string | undefined;
-
-      beforeEach(() => {
-        prevNodeEnv = process.env.NODE_ENV;
-        process.env.NODE_ENV = 'production';
-        mockUploadCompressed.mockResolvedValue(true);
-        mockUploadPlain.mockResolvedValue(true);
-      });
-
-      afterEach(() => {
-        if (prevNodeEnv === undefined) {
-          delete process.env.NODE_ENV;
-        } else {
-          process.env.NODE_ENV = prevNodeEnv;
-        }
-      });
-
-      test('POST …/app/{appId}/sourcemaps/{bundleId} with gzip tarball (201)', async () => {
-        process.env.FARO_BUNDLE_ID = 'rel-201-test';
-        const serializer = createFaroMetroCustomSerializer(null, {
-          appName: 'rn-app',
-          endpoint: 'https://kwl.example.com/api/v1/',
-          appId: 'app-42',
-          stackId: 'stackZ',
-          apiKey: 'secret',
-          skipUpload: false,
-          gzipContents: true,
-        });
-        const graph = { dependencies: new Map() };
-        await serializer('/app/index.js', [], graph, baseOptions());
-
-        expect(mockUploadCompressed).toHaveBeenCalledTimes(1);
-        expect(mockUploadPlain).not.toHaveBeenCalled();
-        expect(mockUploadCompressed).toHaveBeenCalledWith(
-          expect.objectContaining({
-            sourcemapEndpoint:
-              'https://kwl.example.com/api/v1/app/app-42/sourcemaps/rel-201-test',
-            apiKey: 'secret',
-            stackId: 'stackZ',
-          })
-        );
-        const call = mockUploadCompressed.mock.calls[0][0];
-        expect(Array.isArray(call.files)).toBe(true);
-        expect(call.files?.length).toBe(1);
-        expect(String(call.files?.[0] ?? '')).toMatch(/bundle\.js\.map$/);
-      });
-
-      test('POST uses same bundleId segment when FARO_BUNDLE_ID is over max length (hashed)', async () => {
-        const longId = 'b'.repeat(600);
-        process.env.FARO_BUNDLE_ID = longId;
-        const expectedSegment = normalizeBundleIdLength(longId);
-
-        const serializer = createFaroMetroCustomSerializer(null, {
-          appName: 'rn-app',
-          endpoint: 'http://localhost:8000/api/v1',
-          appId: '7',
-          stackId: 's',
-          apiKey: 'k',
-          skipUpload: false,
-        });
-        const graph = { dependencies: new Map() };
-        await serializer('/app/index.js', [], graph, baseOptions());
-
-        expect(mockUploadCompressed).toHaveBeenCalledWith(
-          expect.objectContaining({
-            sourcemapEndpoint: `http://localhost:8000/api/v1/app/7/sourcemaps/${expectedSegment}`,
-          })
-        );
-        expect(expectedSegment).toMatch(/^[a-f0-9]{32}$/);
-      });
-
-      test('gzipContents false uses uploadSourceMap with same sourcemapEndpoint', async () => {
-        process.env.FARO_BUNDLE_ID = 'plain-upload';
-        const serializer = createFaroMetroCustomSerializer(null, {
-          appName: 'rn-app',
-          endpoint: 'http://localhost:8000/api/v1',
-          appId: '1',
-          stackId: 'st',
-          apiKey: 'key',
-          skipUpload: false,
-          gzipContents: false,
-        });
-        const graph = { dependencies: new Map() };
-        await serializer('/app/index.js', [], graph, baseOptions());
-
-        expect(mockUploadPlain).toHaveBeenCalledTimes(1);
-        expect(mockUploadCompressed).not.toHaveBeenCalled();
-        expect(mockUploadPlain).toHaveBeenCalledWith(
-          expect.objectContaining({
-            sourcemapEndpoint:
-              'http://localhost:8000/api/v1/app/1/sourcemaps/plain-upload',
-            apiKey: 'key',
-            stackId: 'st',
-          })
-        );
-        const plainCall = mockUploadPlain.mock.calls[0][0];
-        expect(String(plainCall.filePath ?? '')).toMatch(/bundle\.js\.map$/);
-      });
-
-      test('does not throw when uploadCompressedSourceMaps returns false (API error path)', async () => {
-        process.env.FARO_BUNDLE_ID = 'err-path';
-        mockUploadCompressed.mockResolvedValueOnce(false);
-        const serializer = createFaroMetroCustomSerializer(null, {
-          appName: 'rn-app',
-          endpoint: 'http://localhost:8000/api/v1',
-          appId: '9',
-          stackId: 's',
-          apiKey: 'k',
-          skipUpload: false,
-        });
-        const graph = { dependencies: new Map() };
-        await expect(
-          serializer('/app/index.js', [], graph, baseOptions())
-        ).resolves.toMatchObject({ code: expect.stringContaining('__faroBundleId_rn-app') });
-
-        expect(mockUploadCompressed).toHaveBeenCalledWith(
-          expect.objectContaining({
-            sourcemapEndpoint: 'http://localhost:8000/api/v1/app/9/sourcemaps/err-path',
-          })
-        );
-      });
     });
   });
 });

--- a/packages/faro-metro-plugin/src/test/index.test.ts
+++ b/packages/faro-metro-plugin/src/test/index.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test, afterEach, beforeEach } from '@jest/globals';
+import { jest as jestGlobal } from '@jest/globals';
+import defaultWithFaroConfig, {
+  createFaroMetroCustomSerializer,
+  computeSkipUpload,
+  shiftGeneratedLineNumbers,
+  normalizeBundleIdLength,
+  resolveBundleId,
+} from '../index';
+import {
+  uploadCompressedSourceMaps,
+  uploadSourceMap,
+} from '@grafana/faro-bundlers-shared';
+
+jestGlobal.mock('@grafana/faro-bundlers-shared', () => {
+  const actual = jestGlobal.requireActual('@grafana/faro-bundlers-shared') as Record<string, unknown>;
+  return {
+    ...actual,
+    uploadCompressedSourceMaps: jestGlobal.fn(),
+    uploadSourceMap: jestGlobal.fn(),
+  };
+});
+
+const mockUploadCompressed = jestGlobal.mocked(uploadCompressedSourceMaps);
+const mockUploadPlain = jestGlobal.mocked(uploadSourceMap);
+
+describe('@grafana/faro-metro-plugin', () => {
+  test('withFaroConfig attaches customSerializer', () => {
+    const cfg = defaultWithFaroConfig(
+      { projectRoot: '/x' },
+      {
+        appName: 'metro-test',
+        endpoint: 'http://localhost:8000/faro/api/v1',
+        appId: '1',
+        stackId: 'stack',
+        apiKey: 'key',
+      }
+    );
+    expect(typeof (cfg.serializer as { customSerializer: unknown }).customSerializer).toBe(
+      'function'
+    );
+  });
+
+  test('resolveBundleId uses env FARO_BUNDLE_ID with trimming via hash when too long', () => {
+    const longId = 'a'.repeat(600);
+    const prev = process.env.FARO_BUNDLE_ID;
+    process.env.FARO_BUNDLE_ID = longId;
+    try {
+      const id = resolveBundleId(undefined, false, false);
+      expect(id.length).toBeLessThanOrEqual(512);
+      expect(id.length).toBe(32);
+    } finally {
+      if (prev === undefined) {
+        delete process.env.FARO_BUNDLE_ID;
+      } else {
+        process.env.FARO_BUNDLE_ID = prev;
+      }
+    }
+  });
+
+  test('normalizeBundleIdLength leaves short ids', () => {
+    expect(normalizeBundleIdLength('abc')).toBe('abc');
+  });
+
+  test('computeSkipUpload respects FARO_SKIP_SOURCEMAP_UPLOAD true or 1', () => {
+    const baseOpts = {
+      appName: 'x',
+      endpoint: 'http://e/a',
+      appId: '1',
+      stackId: 's',
+      apiKey: 'k',
+    };
+    const prevNode = process.env.NODE_ENV;
+    const prevSkip = process.env.FARO_SKIP_SOURCEMAP_UPLOAD;
+    try {
+      process.env.NODE_ENV = 'production';
+      process.env.FARO_SKIP_SOURCEMAP_UPLOAD = 'true';
+      expect(
+        computeSkipUpload({
+          ...baseOpts,
+        })
+      ).toBe(true);
+      process.env.FARO_SKIP_SOURCEMAP_UPLOAD = 'TRUE';
+      expect(computeSkipUpload({ ...baseOpts })).toBe(true);
+      process.env.FARO_SKIP_SOURCEMAP_UPLOAD = '0';
+      expect(computeSkipUpload({ ...baseOpts })).toBe(false);
+      process.env.FARO_SKIP_SOURCEMAP_UPLOAD = '1';
+      expect(computeSkipUpload({ ...baseOpts })).toBe(true);
+    } finally {
+      process.env.NODE_ENV = prevNode;
+      if (prevSkip === undefined) {
+        delete process.env.FARO_SKIP_SOURCEMAP_UPLOAD;
+      } else {
+        process.env.FARO_SKIP_SOURCEMAP_UPLOAD = prevSkip;
+      }
+    }
+  });
+
+  test('shiftGeneratedLineNumbers offsets mappings', async () => {
+    const map = {
+      version: 3,
+      file: 'out.js',
+      sources: ['a.js'],
+      names: [],
+      sourcesContent: ['console.log(1);\n'],
+      mappings: 'AAAA',
+    };
+    const shifted = await shiftGeneratedLineNumbers(map, 1);
+    expect(shifted.version).toBe(3);
+  });
+
+  describe('custom serializer', () => {
+    const baseOptions = () => {
+      const ids = new Map<string, number>();
+      let n = 1;
+      const createModuleId = (p: string) => {
+        if (!ids.has(p)) ids.set(p, n++);
+        return ids.get(p)!;
+      };
+      return {
+        asyncRequireModulePath: '',
+        processModuleFilter: () => true,
+        createModuleId,
+        getRunModuleStatement: (_moduleId: string) => `__r(${_moduleId});`,
+        globalPrefix: '',
+        dev: false,
+        includeAsyncPaths: false,
+        projectRoot: '/app',
+        modulesOnly: false,
+        runBeforeMainModule: [] as string[],
+        runModule: true,
+        sourceMapUrl: 'index.bundle.map',
+        sourceUrl: '',
+        inlineSourceMap: false,
+        serverRoot: '/app',
+        shouldAddToIgnoreList: () => false,
+        getSourceUrl: () => '',
+      };
+    };
+
+    afterEach(() => {
+      delete process.env.FARO_BUNDLE_ID;
+      delete process.env.FARO_SKIP_SOURCEMAP_UPLOAD;
+      mockUploadCompressed.mockClear();
+      mockUploadPlain.mockClear();
+    });
+
+    test('prepends faro bundle id snippet (release bundle)', async () => {
+      process.env.FARO_BUNDLE_ID = 'release-id-1';
+      const serializer = createFaroMetroCustomSerializer(null, {
+        appName: 'rn-app',
+        endpoint: 'http://localhost:8000/faro/api/v1',
+        appId: '42',
+        stackId: 'stack',
+        apiKey: 'k',
+        skipUpload: true,
+      });
+      const graph = { dependencies: new Map() };
+      const out = await serializer('/app/index.js', [], graph, baseOptions());
+      expect(out.code).toContain('__faroBundleId_rn-app');
+      expect(out.code).toContain('"release-id-1"');
+      const parsed = JSON.parse(out.map) as { version: number };
+      expect(parsed.version).toBe(3);
+    });
+
+    test('uses dev placeholder when dev or skip', async () => {
+      const serializer = createFaroMetroCustomSerializer(null, {
+        appName: 'rn-app',
+        endpoint: 'http://localhost:8000/faro/api/v1',
+        appId: '42',
+        stackId: 'stack',
+        apiKey: 'k',
+        skipUpload: true,
+      });
+      const graph = { dependencies: new Map() };
+      const opts = { ...baseOptions(), dev: true };
+      const out = await serializer('/app/index.js', [], graph, opts);
+      expect(out.code).toMatch(/dev-[a-f0-9]+/);
+    });
+
+    describe('release upload to source map API', () => {
+      let prevNodeEnv: string | undefined;
+
+      beforeEach(() => {
+        prevNodeEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = 'production';
+        mockUploadCompressed.mockResolvedValue(true);
+        mockUploadPlain.mockResolvedValue(true);
+      });
+
+      afterEach(() => {
+        if (prevNodeEnv === undefined) {
+          delete process.env.NODE_ENV;
+        } else {
+          process.env.NODE_ENV = prevNodeEnv;
+        }
+      });
+
+      test('POST …/app/{appId}/sourcemaps/{bundleId} with gzip tarball (201)', async () => {
+        process.env.FARO_BUNDLE_ID = 'rel-201-test';
+        const serializer = createFaroMetroCustomSerializer(null, {
+          appName: 'rn-app',
+          endpoint: 'https://kwl.example.com/api/v1/',
+          appId: 'app-42',
+          stackId: 'stackZ',
+          apiKey: 'secret',
+          skipUpload: false,
+          gzipContents: true,
+        });
+        const graph = { dependencies: new Map() };
+        await serializer('/app/index.js', [], graph, baseOptions());
+
+        expect(mockUploadCompressed).toHaveBeenCalledTimes(1);
+        expect(mockUploadPlain).not.toHaveBeenCalled();
+        expect(mockUploadCompressed).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sourcemapEndpoint:
+              'https://kwl.example.com/api/v1/app/app-42/sourcemaps/rel-201-test',
+            apiKey: 'secret',
+            stackId: 'stackZ',
+          })
+        );
+        const call = mockUploadCompressed.mock.calls[0][0];
+        expect(Array.isArray(call.files)).toBe(true);
+        expect(call.files?.length).toBe(1);
+        expect(String(call.files?.[0] ?? '')).toMatch(/bundle\.js\.map$/);
+      });
+
+      test('POST uses same bundleId segment when FARO_BUNDLE_ID is over max length (hashed)', async () => {
+        const longId = 'b'.repeat(600);
+        process.env.FARO_BUNDLE_ID = longId;
+        const expectedSegment = normalizeBundleIdLength(longId);
+
+        const serializer = createFaroMetroCustomSerializer(null, {
+          appName: 'rn-app',
+          endpoint: 'http://localhost:8000/api/v1',
+          appId: '7',
+          stackId: 's',
+          apiKey: 'k',
+          skipUpload: false,
+        });
+        const graph = { dependencies: new Map() };
+        await serializer('/app/index.js', [], graph, baseOptions());
+
+        expect(mockUploadCompressed).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sourcemapEndpoint: `http://localhost:8000/api/v1/app/7/sourcemaps/${expectedSegment}`,
+          })
+        );
+        expect(expectedSegment).toMatch(/^[a-f0-9]{32}$/);
+      });
+
+      test('gzipContents false uses uploadSourceMap with same sourcemapEndpoint', async () => {
+        process.env.FARO_BUNDLE_ID = 'plain-upload';
+        const serializer = createFaroMetroCustomSerializer(null, {
+          appName: 'rn-app',
+          endpoint: 'http://localhost:8000/api/v1',
+          appId: '1',
+          stackId: 'st',
+          apiKey: 'key',
+          skipUpload: false,
+          gzipContents: false,
+        });
+        const graph = { dependencies: new Map() };
+        await serializer('/app/index.js', [], graph, baseOptions());
+
+        expect(mockUploadPlain).toHaveBeenCalledTimes(1);
+        expect(mockUploadCompressed).not.toHaveBeenCalled();
+        expect(mockUploadPlain).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sourcemapEndpoint:
+              'http://localhost:8000/api/v1/app/1/sourcemaps/plain-upload',
+            apiKey: 'key',
+            stackId: 'st',
+          })
+        );
+        const plainCall = mockUploadPlain.mock.calls[0][0];
+        expect(String(plainCall.filePath ?? '')).toMatch(/bundle\.js\.map$/);
+      });
+
+      test('does not throw when uploadCompressedSourceMaps returns false (API error path)', async () => {
+        process.env.FARO_BUNDLE_ID = 'err-path';
+        mockUploadCompressed.mockResolvedValueOnce(false);
+        const serializer = createFaroMetroCustomSerializer(null, {
+          appName: 'rn-app',
+          endpoint: 'http://localhost:8000/api/v1',
+          appId: '9',
+          stackId: 's',
+          apiKey: 'k',
+          skipUpload: false,
+        });
+        const graph = { dependencies: new Map() };
+        await expect(
+          serializer('/app/index.js', [], graph, baseOptions())
+        ).resolves.toMatchObject({ code: expect.stringContaining('__faroBundleId_rn-app') });
+
+        expect(mockUploadCompressed).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sourcemapEndpoint: 'http://localhost:8000/api/v1/app/9/sourcemaps/err-path',
+          })
+        );
+      });
+    });
+  });
+});

--- a/packages/faro-metro-plugin/src/test/path-a-fixture.test.ts
+++ b/packages/faro-metro-plugin/src/test/path-a-fixture.test.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import fs from 'fs';
+import { describe, expect, test } from '@jest/globals';
+
+/**
+ * Path A (plan §1b): assert a release `.map` from `react-native bundle` shape
+ * parses without running the full RN CLI in unit tests.
+ */
+describe('Path A release source map fixture', () => {
+  test('parses as JSON v3 with non-empty sources and bundle file field', () => {
+    const mapPath = path.join(
+      __dirname,
+      'fixtures',
+      'path-a-release.index.android.bundle.map'
+    );
+    const raw = fs.readFileSync(mapPath, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      version: number;
+      sources: string[];
+      file: string;
+    };
+
+    expect(parsed.version).toBe(3);
+    expect(Array.isArray(parsed.sources)).toBe(true);
+    expect(parsed.sources.length).toBeGreaterThan(0);
+    expect(typeof parsed.file).toBe('string');
+    expect(parsed.file).toBe('index.android.bundle');
+  });
+});

--- a/packages/faro-metro-plugin/tsconfig.json
+++ b/packages/faro-metro-plugin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@grafana/tsconfig",
+  "include": ["./**/*"],
+  "compilerOptions": {
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "module": "Node18",
+    "moduleResolution": "Node16"
+  }
+}

--- a/packages/faro-rollup/src/test/index.test.ts
+++ b/packages/faro-rollup/src/test/index.test.ts
@@ -60,7 +60,11 @@ describe('Faro Rollup Plugin', () => {
   test('basic bundleId injection test', async () => {
     const output = await runRollup({ bundleId: 'test' });
 
-    expect(output.output[0].code.startsWith(`(function(){try{var g=typeof window!=="undefined"?window:typeof global!=="undefined"?global:typeof self!=="undefined"?self:{};g["__faroBundleId_rollup-test-app"]="test"`)).toBeTruthy();
+    expect(
+      output.output[0].code.startsWith(
+        `(function(){try{var g=typeof globalThis!=="undefined"?globalThis:typeof global!=="undefined"?global:typeof window!=="undefined"?window:typeof self!=="undefined"?self:{};g["__faroBundleId_rollup-test-app"]="test"`
+      )
+    ).toBeTruthy();
   });
 
   test('custom bundleId is correctly injected', async () => {
@@ -96,7 +100,8 @@ describe('Faro Rollup Plugin', () => {
     const output = await runRollup({ bundleId: 'test' });
 
     // Create a simple regex to check code starts with the bundle ID snippet
-    const bundleIdRegex = /^\(function\(\)\{try\{var g=typeof window!=="undefined"\?window:typeof global!=="undefined"\?global:typeof self!=="undefined"\?self:\{\};g\["__faroBundleId_rollup-test-app"\]="test"\}catch\(l\)\{\}\}\)\(\);/;
+    const bundleIdRegex =
+      /^\(function\(\)\{try\{var g=typeof globalThis!=="undefined"\?globalThis:typeof global!=="undefined"\?global:typeof window!=="undefined"\?window:typeof self!=="undefined"\?self:\{\};g\["__faroBundleId_rollup-test-app"\]="test"\}catch\(l\)\{\}\}\)\(\);/;
 
     expect(output.output[0].code).toMatch(bundleIdRegex);
   });

--- a/packages/faro-webpack/jest.config.js
+++ b/packages/faro-webpack/jest.config.js
@@ -3,10 +3,20 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/test/*.test.ts'],
-  moduleFileExtensions: ['ts', 'js', 'json'],
+  moduleFileExtensions: ['ts', 'js', 'mjs', 'json'],
+  setupFiles: ['<rootDir>/src/test/setup.ts'],
+  // msw@2 pulls ESM-only deps (e.g. rettime); transpile them for Jest.
+  transformIgnorePatterns: [
+    '/node_modules/(?!(msw|@mswjs|@open-draft|rettime|until-async|strict-event-emitter|@bundled-es-modules)/)',
+  ],
   transform: {
     '^.+\\.ts$': ['ts-jest', {
       tsconfig: 'tsconfig.json',
+    }],
+    '^.+\\.(js|mjs)$': ['babel-jest', {
+      presets: [
+        ['@babel/preset-env', { targets: { node: 'current' } }],
+      ],
     }],
   },
 };

--- a/packages/faro-webpack/jest.config.js
+++ b/packages/faro-webpack/jest.config.js
@@ -4,7 +4,6 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/test/*.test.ts'],
   moduleFileExtensions: ['ts', 'js', 'mjs', 'json'],
-  setupFiles: ['<rootDir>/src/test/setup.ts'],
   // msw@2 pulls ESM-only deps (e.g. rettime); transpile them for Jest.
   transformIgnorePatterns: [
     '/node_modules/(?!(msw|@mswjs|@open-draft|rettime|until-async|strict-event-emitter|@bundled-es-modules)/)',

--- a/packages/faro-webpack/package.json
+++ b/packages/faro-webpack/package.json
@@ -24,7 +24,7 @@
     "@babel/core": "7.29.0",
     "@babel/preset-env": "7.29.3",
     "@jest/globals": "30.4.1",
-    "babel-jest": "30.3.0",
+    "babel-jest": "30.4.1",
     "@rollup/plugin-babel": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@types/jest": "30.0.0",

--- a/packages/faro-webpack/package.json
+++ b/packages/faro-webpack/package.json
@@ -21,7 +21,10 @@
     "webpack": "^5.89.0"
   },
   "devDependencies": {
+    "@babel/core": "7.29.0",
+    "@babel/preset-env": "7.29.3",
     "@jest/globals": "30.4.1",
+    "babel-jest": "30.3.0",
     "@rollup/plugin-babel": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@types/jest": "30.0.0",

--- a/packages/faro-webpack/package.json
+++ b/packages/faro-webpack/package.json
@@ -24,11 +24,11 @@
     "@babel/core": "7.29.0",
     "@babel/preset-env": "7.29.3",
     "@jest/globals": "30.4.1",
-    "babel-jest": "30.4.1",
     "@rollup/plugin-babel": "6.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@types/jest": "30.0.0",
     "@types/node": "24.12.4",
+    "babel-jest": "30.4.1",
     "jest": "30.4.2",
     "ts-jest": "29.4.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:7.29.0, @babel/core@npm:^7.23.9, @babel/core@npm:^7.27.4":
+"@babel/core@npm:7.29.0, @babel/core@npm:^7.23.9, @babel/core@npm:^7.25.2, @babel/core@npm:^7.27.4":
   version: 7.29.0
   resolution: "@babel/core@npm:7.29.0"
   dependencies:
@@ -46,7 +46,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.27.5, @babel/generator@npm:^7.29.0":
+"@babel/generator@npm:^7.27.5, @babel/generator@npm:^7.29.0, @babel/generator@npm:^7.29.1":
   version: 7.29.1
   resolution: "@babel/generator@npm:7.29.1"
   dependencies:
@@ -857,7 +857,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-transform-modules-systemjs@npm:^7.29.4":
+"@babel/plugin-transform-modules-systemjs@npm:^7.29.0, @babel/plugin-transform-modules-systemjs@npm:^7.29.4":
   version: 7.29.4
   resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.4"
   dependencies:
@@ -1177,6 +1177,87 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/preset-env@npm:7.29.3":
+  version: 7.29.3
+  resolution: "@babel/preset-env@npm:7.29.3"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.3"
+    "@babel/helper-compilation-targets": "npm:^7.28.6"
+    "@babel/helper-plugin-utils": "npm:^7.28.6"
+    "@babel/helper-validator-option": "npm:^7.27.1"
+    "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "npm:^7.28.5"
+    "@babel/plugin-bugfix-safari-class-field-initializer-scope": "npm:^7.27.1"
+    "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "npm:^7.27.1"
+    "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": "npm:^7.29.3"
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "npm:^7.27.1"
+    "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "npm:^7.28.6"
+    "@babel/plugin-proposal-private-property-in-object": "npm:7.21.0-placeholder-for-preset-env.2"
+    "@babel/plugin-syntax-import-assertions": "npm:^7.28.6"
+    "@babel/plugin-syntax-import-attributes": "npm:^7.28.6"
+    "@babel/plugin-syntax-unicode-sets-regex": "npm:^7.18.6"
+    "@babel/plugin-transform-arrow-functions": "npm:^7.27.1"
+    "@babel/plugin-transform-async-generator-functions": "npm:^7.29.0"
+    "@babel/plugin-transform-async-to-generator": "npm:^7.28.6"
+    "@babel/plugin-transform-block-scoped-functions": "npm:^7.27.1"
+    "@babel/plugin-transform-block-scoping": "npm:^7.28.6"
+    "@babel/plugin-transform-class-properties": "npm:^7.28.6"
+    "@babel/plugin-transform-class-static-block": "npm:^7.28.6"
+    "@babel/plugin-transform-classes": "npm:^7.28.6"
+    "@babel/plugin-transform-computed-properties": "npm:^7.28.6"
+    "@babel/plugin-transform-destructuring": "npm:^7.28.5"
+    "@babel/plugin-transform-dotall-regex": "npm:^7.28.6"
+    "@babel/plugin-transform-duplicate-keys": "npm:^7.27.1"
+    "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "npm:^7.29.0"
+    "@babel/plugin-transform-dynamic-import": "npm:^7.27.1"
+    "@babel/plugin-transform-explicit-resource-management": "npm:^7.28.6"
+    "@babel/plugin-transform-exponentiation-operator": "npm:^7.28.6"
+    "@babel/plugin-transform-export-namespace-from": "npm:^7.27.1"
+    "@babel/plugin-transform-for-of": "npm:^7.27.1"
+    "@babel/plugin-transform-function-name": "npm:^7.27.1"
+    "@babel/plugin-transform-json-strings": "npm:^7.28.6"
+    "@babel/plugin-transform-literals": "npm:^7.27.1"
+    "@babel/plugin-transform-logical-assignment-operators": "npm:^7.28.6"
+    "@babel/plugin-transform-member-expression-literals": "npm:^7.27.1"
+    "@babel/plugin-transform-modules-amd": "npm:^7.27.1"
+    "@babel/plugin-transform-modules-commonjs": "npm:^7.28.6"
+    "@babel/plugin-transform-modules-systemjs": "npm:^7.29.0"
+    "@babel/plugin-transform-modules-umd": "npm:^7.27.1"
+    "@babel/plugin-transform-named-capturing-groups-regex": "npm:^7.29.0"
+    "@babel/plugin-transform-new-target": "npm:^7.27.1"
+    "@babel/plugin-transform-nullish-coalescing-operator": "npm:^7.28.6"
+    "@babel/plugin-transform-numeric-separator": "npm:^7.28.6"
+    "@babel/plugin-transform-object-rest-spread": "npm:^7.28.6"
+    "@babel/plugin-transform-object-super": "npm:^7.27.1"
+    "@babel/plugin-transform-optional-catch-binding": "npm:^7.28.6"
+    "@babel/plugin-transform-optional-chaining": "npm:^7.28.6"
+    "@babel/plugin-transform-parameters": "npm:^7.27.7"
+    "@babel/plugin-transform-private-methods": "npm:^7.28.6"
+    "@babel/plugin-transform-private-property-in-object": "npm:^7.28.6"
+    "@babel/plugin-transform-property-literals": "npm:^7.27.1"
+    "@babel/plugin-transform-regenerator": "npm:^7.29.0"
+    "@babel/plugin-transform-regexp-modifiers": "npm:^7.28.6"
+    "@babel/plugin-transform-reserved-words": "npm:^7.27.1"
+    "@babel/plugin-transform-shorthand-properties": "npm:^7.27.1"
+    "@babel/plugin-transform-spread": "npm:^7.28.6"
+    "@babel/plugin-transform-sticky-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-template-literals": "npm:^7.27.1"
+    "@babel/plugin-transform-typeof-symbol": "npm:^7.27.1"
+    "@babel/plugin-transform-unicode-escapes": "npm:^7.27.1"
+    "@babel/plugin-transform-unicode-property-regex": "npm:^7.28.6"
+    "@babel/plugin-transform-unicode-regex": "npm:^7.27.1"
+    "@babel/plugin-transform-unicode-sets-regex": "npm:^7.28.6"
+    "@babel/preset-modules": "npm:0.1.6-no-external-plugins"
+    babel-plugin-polyfill-corejs2: "npm:^0.4.15"
+    babel-plugin-polyfill-corejs3: "npm:^0.14.0"
+    babel-plugin-polyfill-regenerator: "npm:^0.6.6"
+    core-js-compat: "npm:^3.48.0"
+    semver: "npm:^6.3.1"
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 10/723676e883ac22bdf24000aad81a2f0a86e9b17c520423df4d54d34b6e183c8c2609019d745bcbb453bd11d9273aee237e641d2cdc27744ef6a494df96f18fb8
+  languageName: node
+  linkType: hard
+
 "@babel/preset-env@npm:7.29.5":
   version: 7.29.5
   resolution: "@babel/preset-env@npm:7.29.5"
@@ -1283,6 +1364,13 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10/72c03e01c34906041b1813542761a283c52da1751e7ddf63191bc5fb2a0354eca30a00537c5a92951688bec3975bdc0e50ef4516b5e94cfd6d4cf947f2125bdc
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.25.0":
+  version: 7.29.2
+  resolution: "@babel/runtime@npm:7.29.2"
+  checksum: 10/f55ba4052aa0255055b34371a145fbe69c29b37b49eaea14805b095bfb4153701486416e89392fd27ec8abafa53868be86e960b9f8f959fff91f2c8ac2a14b02
   languageName: node
   linkType: hard
 
@@ -1574,7 +1662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/faro-bundlers-shared@npm:^0.10.1, @grafana/faro-bundlers-shared@workspace:packages/faro-bundlers-shared":
+"@grafana/faro-bundlers-shared@npm:^0.10.0, @grafana/faro-bundlers-shared@npm:^0.10.1, @grafana/faro-bundlers-shared@workspace:packages/faro-bundlers-shared":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-bundlers-shared@workspace:packages/faro-bundlers-shared"
   dependencies:
@@ -1587,7 +1675,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/faro-cli@workspace:packages/faro-cli":
+"@grafana/faro-cli@npm:^0.10.0, @grafana/faro-cli@workspace:packages/faro-cli":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-cli@workspace:packages/faro-cli"
   dependencies:
@@ -1622,6 +1710,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana/faro-metro-plugin@workspace:packages/faro-metro-plugin":
+  version: 0.0.0-use.local
+  resolution: "@grafana/faro-metro-plugin@workspace:packages/faro-metro-plugin"
+  dependencies:
+    "@grafana/faro-bundlers-shared": "npm:^0.10.0"
+    "@grafana/faro-cli": "npm:^0.10.0"
+    "@jest/globals": "npm:30.4.1"
+    "@rollup/plugin-babel": "npm:6.1.0"
+    "@rollup/plugin-commonjs": "npm:29.0.2"
+    "@rollup/plugin-json": "npm:6.1.0"
+    "@rollup/plugin-node-resolve": "npm:16.0.3"
+    "@rollup/plugin-typescript": "npm:11.1.6"
+    "@types/jest": "npm:30.0.0"
+    "@types/node": "npm:24.12.2"
+    cross-fetch: "npm:^4.0.0"
+    jest: "npm:30.4.1"
+    metro: "npm:0.83.6"
+    source-map: "npm:^0.7.4"
+    ts-jest: "npm:29.4.9"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    metro: ">=0.81.0"
+  bin:
+    faro-upload-source-map: bin/faro-upload-source-map.js
+  languageName: unknown
+  linkType: soft
+
 "@grafana/faro-rollup-plugin@workspace:packages/faro-rollup":
   version: 0.0.0-use.local
   resolution: "@grafana/faro-rollup-plugin@workspace:packages/faro-rollup"
@@ -1640,12 +1755,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/faro-webpack-plugin@workspace:packages/faro-webpack"
   dependencies:
+    "@babel/core": "npm:7.29.0"
+    "@babel/preset-env": "npm:7.29.3"
     "@grafana/faro-bundlers-shared": "npm:^0.10.1"
     "@jest/globals": "npm:30.4.1"
     "@rollup/plugin-babel": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:16.0.3"
     "@types/jest": "npm:30.0.0"
     "@types/node": "npm:24.12.4"
+    babel-jest: "npm:30.4.1"
     jest: "npm:30.4.2"
     ts-jest: "npm:29.4.9"
     webpack: "npm:^5.89.0"
@@ -1984,6 +2102,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/core@npm:30.4.1":
+  version: 30.4.1
+  resolution: "@jest/core@npm:30.4.1"
+  dependencies:
+    "@jest/console": "npm:30.4.1"
+    "@jest/pattern": "npm:30.4.0"
+    "@jest/reporters": "npm:30.4.1"
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/transform": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    ansi-escapes: "npm:^4.3.2"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    exit-x: "npm:^0.2.2"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    graceful-fs: "npm:^4.2.11"
+    jest-changed-files: "npm:30.4.1"
+    jest-config: "npm:30.4.1"
+    jest-haste-map: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-regex-util: "npm:30.4.0"
+    jest-resolve: "npm:30.4.1"
+    jest-resolve-dependencies: "npm:30.4.1"
+    jest-runner: "npm:30.4.1"
+    jest-runtime: "npm:30.4.1"
+    jest-snapshot: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    jest-validate: "npm:30.4.1"
+    jest-watcher: "npm:30.4.1"
+    pretty-format: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  checksum: 10/812fb0bb2da9251daf5e6c279d27a5808a1d73cc4362df9708706adf285ba6882d4be1ec817994579427f7562e80becf16dace1e7792b797d2cb0996ef12d5e0
+  languageName: node
+  linkType: hard
+
 "@jest/core@npm:30.4.2":
   version: 30.4.2
   resolution: "@jest/core@npm:30.4.2"
@@ -2158,6 +2317,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jest/schemas@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/schemas@npm:29.6.3"
+  dependencies:
+    "@sinclair/typebox": "npm:^0.27.8"
+  checksum: 10/910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
+  languageName: node
+  linkType: hard
+
 "@jest/snapshot-utils@npm:30.4.1":
   version: 30.4.1
   resolution: "@jest/snapshot-utils@npm:30.4.1"
@@ -2239,6 +2407,20 @@ __metadata:
     "@types/yargs": "npm:^17.0.33"
     chalk: "npm:^4.1.2"
   checksum: 10/cc0999508613487c6d0f55661cd342ebe7cfe579fa9917534b94310204358f03f94524f70f00b4fe3c6dd2ccd0fd44657615a1b9f420ab310d68b43964bff87c
+  languageName: node
+  linkType: hard
+
+"@jest/types@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "@jest/types@npm:29.6.3"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    "@types/istanbul-lib-coverage": "npm:^2.0.0"
+    "@types/istanbul-reports": "npm:^3.0.0"
+    "@types/node": "npm:*"
+    "@types/yargs": "npm:^17.0.8"
+    chalk: "npm:^4.0.0"
+  checksum: 10/f74bf512fd09bbe2433a2ad460b04668b7075235eea9a0c77d6a42222c10a79b9747dc2b2a623f140ed40d6865a2ed8f538f3cbb75169120ea863f29a7ed76cd
   languageName: node
   linkType: hard
 
@@ -3171,6 +3353,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sinclair/typebox@npm:^0.27.8":
+  version: 0.27.10
+  resolution: "@sinclair/typebox@npm:0.27.10"
+  checksum: 10/1498c5ef1375787e6272528615d5c262afb60873191d2441316359817b1c411917063c8be102ef15b0b5c62243a9daa7aefc8426f20eb406b67038b3eaa0695a
+  languageName: node
+  linkType: hard
+
 "@sinclair/typebox@npm:^0.34.0":
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
@@ -3315,7 +3504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1, @types/istanbul-lib-coverage@npm:^2.0.6":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 10/3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
@@ -3331,7 +3520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-reports@npm:^3.0.4":
+"@types/istanbul-reports@npm:^3.0.0, @types/istanbul-reports@npm:^3.0.4":
   version: 3.0.4
   resolution: "@types/istanbul-reports@npm:3.0.4"
   dependencies:
@@ -3370,6 +3559,15 @@ __metadata:
   dependencies:
     undici-types: "npm:~7.21.0"
   checksum: 10/1b11c865ea517ab90af870c2f58c100804e3dd8dc25a62b5e5af3aea12ad015f9faf513664babc7e0c755bb1c0744649b2ff19b7b434c1648ad8057f2dc6c71a
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:24.12.2":
+  version: 24.12.2
+  resolution: "@types/node@npm:24.12.2"
+  dependencies:
+    undici-types: "npm:~7.16.0"
+  checksum: 10/99b9f15e67a4b3c39b39ad83ee0febad7f0b4709c004863104d7acfa4146dd7e58c12a08a9a7ff2be8c2eefd0063bf991fade0879d7c4a370a0ee7fd4c799e8a
   languageName: node
   linkType: hard
 
@@ -3419,7 +3617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.33":
+"@types/yargs@npm:^17.0.33, @types/yargs@npm:^17.0.8":
   version: 17.0.35
   resolution: "@types/yargs@npm:17.0.35"
   dependencies:
@@ -3779,6 +3977,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10/ea1343992b40b2bfb3a3113fa9c3c2f918ba0f9197ae565c48d3f84d44b174f6b1d5cd9989decd7655963eb03a272abc36968cc439c2907f999bd5ef8653d5a7
+  languageName: node
+  linkType: hard
+
 "acorn-import-phases@npm:^1.0.3":
   version: 1.0.4
   resolution: "acorn-import-phases@npm:1.0.4"
@@ -3897,7 +4105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.2.0":
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10/d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
@@ -4195,6 +4403,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"braces@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
+  dependencies:
+    fill-range: "npm:^7.1.1"
+  checksum: 10/fad11a0d4697a27162840b02b1fad249c1683cbc510cd5bf1a471f2f8085c046d41094308c577a50a03a579dd99d5a6b3724c4b5e8b14df2c4443844cfcda2c6
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
   version: 4.28.2
   resolution: "browserslist@npm:4.28.2"
@@ -4305,7 +4522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"camelcase@npm:^6.3.0":
+"camelcase@npm:^6.2.0, camelcase@npm:^6.3.0":
   version: 6.3.0
   resolution: "camelcase@npm:6.3.0"
   checksum: 10/8c96818a9076434998511251dcb2761a94817ea17dbdc37f47ac080bd088fc62c7369429a19e2178b993497132c8cbcf5cc1f44ba963e76782ba469c0474938d
@@ -4329,7 +4546,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -4371,6 +4588,13 @@ __metadata:
   version: 4.3.1
   resolution: "ci-info@npm:4.3.1"
   checksum: 10/9dc952bef67e665ccde2e7a552d42d5d095529d21829ece060a00925ede2dfa136160c70ef2471ea6ed6c9b133218b47c007f56955c0f1734a2e57f240aa7445
+  languageName: node
+  linkType: hard
+
+"ci-info@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ci-info@npm:2.0.0"
+  checksum: 10/3b374666a85ea3ca43fa49aa3a048d21c9b475c96eb13c133505d2324e7ae5efd6a454f41efe46a152269e9b6a00c9edbe63ec7fa1921957165aae16625acd67
   languageName: node
   linkType: hard
 
@@ -4583,6 +4807,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"connect@npm:^3.6.5":
+  version: 3.7.0
+  resolution: "connect@npm:3.7.0"
+  dependencies:
+    debug: "npm:2.6.9"
+    finalhandler: "npm:1.1.2"
+    parseurl: "npm:~1.3.3"
+    utils-merge: "npm:1.0.1"
+  checksum: 10/f94818b198cc662092276ef6757dd825c59c8469c8064583525e7b81d39a3af86a01c7cb76107dfa0295dfc52b27a7ae1c40ea0e0a10189c3f8776cf08ce3a4e
+  languageName: node
+  linkType: hard
+
 "console-control-strings@npm:^1.1.0":
   version: 1.1.0
   resolution: "console-control-strings@npm:1.1.0"
@@ -4723,6 +4959,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-fetch@npm:^4.0.0":
+  version: 4.1.0
+  resolution: "cross-fetch@npm:4.1.0"
+  dependencies:
+    node-fetch: "npm:^2.7.0"
+  checksum: 10/07624940607b64777d27ec9c668ddb6649e8c59ee0a5a10e63a51ce857e2bbb1294a45854a31c10eccb91b65909a5b199fcb0217339b44156f85900a7384f489
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
@@ -4757,7 +5002,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.3":
+"debug@npm:2.6.9":
+  version: 2.6.9
+  resolution: "debug@npm:2.6.9"
+  dependencies:
+    ms: "npm:2.0.0"
+  checksum: 10/e07005f2b40e04f1bd14a3dd20520e9c4f25f60224cb006ce9d6781732c917964e9ec029fc7f1a151083cd929025ad5133814d4dc624a9aaf020effe4914ed14
+  languageName: node
+  linkType: hard
+
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.4, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -4911,6 +5165,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ee-first@npm:1.1.1":
+  version: 1.1.1
+  resolution: "ee-first@npm:1.1.1"
+  checksum: 10/1b4cac778d64ce3b582a7e26b218afe07e207a0f9bfe13cc7395a6d307849cfe361e65033c3251e00c27dd060cab43014c2d6b2647676135e18b77d2d05b3f4f
+  languageName: node
+  linkType: hard
+
 "ejs@npm:5.0.1":
   version: 5.0.1
   resolution: "ejs@npm:5.0.1"
@@ -4945,6 +5206,13 @@ __metadata:
   version: 9.2.2
   resolution: "emoji-regex@npm:9.2.2"
   checksum: 10/915acf859cea7131dac1b2b5c9c8e35c4849e325a1d114c30adb8cd615970f6dca0e27f64f3a4949d7d6ed86ecd79a1c5c63f02e697513cddd7b5835c90948b8
+  languageName: node
+  linkType: hard
+
+"encodeurl@npm:~1.0.2":
+  version: 1.0.2
+  resolution: "encodeurl@npm:1.0.2"
+  checksum: 10/e50e3d508cdd9c4565ba72d2012e65038e5d71bdc9198cb125beb6237b5b1ade6c0d343998da9e170fb2eae52c1bed37d4d6d98a46ea423a0cddbed5ac3f780c
   languageName: node
   linkType: hard
 
@@ -5014,6 +5282,15 @@ __metadata:
   dependencies:
     is-arrayish: "npm:^0.2.1"
   checksum: 10/ae3939fd4a55b1404e877df2080c6b59acc516d5b7f08a181040f78f38b4e2399633bfed2d9a21b91c803713fff7295ac70bebd8f3657ef352a95c2cd9aa2e4b
+  languageName: node
+  linkType: hard
+
+"error-stack-parser@npm:^2.0.6":
+  version: 2.1.4
+  resolution: "error-stack-parser@npm:2.1.4"
+  dependencies:
+    stackframe: "npm:^1.3.4"
+  checksum: 10/23db33135bfc6ba701e5eee45e1bb9bd2fe33c5d4f9927440d9a499c7ac538f91f455fcd878611361269893c56734419252c40d8105eb3b023cf8b0fc2ebb64e
   languageName: node
   linkType: hard
 
@@ -5152,6 +5429,13 @@ __metadata:
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
   checksum: 10/9d7169e3965b2f9ae46971afa392f6e5a25545ea30f2e2dd99c9b0a95a3f52b5653681a84f5b2911a413ddad2d7a93d3514165072f349b5ffc59c75a899970d6
+  languageName: node
+  linkType: hard
+
+"escape-html@npm:~1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10/6213ca9ae00d0ab8bccb6d8d4e0a98e76237b2410302cf7df70aaa6591d509a2a37ce8998008cbecae8fc8ffaadf3fb0229535e6a145f3ce0b211d060decbb24
   languageName: node
   linkType: hard
 
@@ -5341,7 +5625,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fb-watchman@npm:^2.0.2":
+"fb-watchman@npm:^2.0.0, fb-watchman@npm:^2.0.2":
   version: 2.0.2
   resolution: "fb-watchman@npm:2.0.2"
   dependencies:
@@ -5371,6 +5655,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
+  dependencies:
+    to-regex-range: "npm:^5.0.1"
+  checksum: 10/a7095cb39e5bc32fada2aa7c7249d3f6b01bd1ce461a61b0adabacccabd9198500c6fb1f68a7c851a657e273fce2233ba869638897f3d7ed2e87a2d89b4436ea
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:1.1.2":
+  version: 1.1.2
+  resolution: "finalhandler@npm:1.1.2"
+  dependencies:
+    debug: "npm:2.6.9"
+    encodeurl: "npm:~1.0.2"
+    escape-html: "npm:~1.0.3"
+    on-finished: "npm:~2.3.0"
+    parseurl: "npm:~1.3.3"
+    statuses: "npm:~1.5.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10/351e99a889abf149eb3edb24568586469feeb3019f5eafb9b31e632a5ad886f12a5595a221508245e6a37da69ae866c9fb411eb541a844238e2c900f63ac1576
+  languageName: node
+  linkType: hard
+
 "find-up@npm:^2.0.0":
   version: 2.1.0
   resolution: "find-up@npm:2.1.0"
@@ -5396,6 +5704,13 @@ __metadata:
   bin:
     flat: cli.js
   checksum: 10/72479e651c15eab53e25ce04c31bab18cfaac0556505cac19221dbbe85bbb9686bc76e4d397e89e5bf516ce667dcf818f8b07e585568edba55abc2bf1f698fb5
+  languageName: node
+  linkType: hard
+
+"flow-enums-runtime@npm:^0.0.6":
+  version: 0.0.6
+  resolution: "flow-enums-runtime@npm:0.0.6"
+  checksum: 10/df54ec17f6edbe2bcf17cb1e681faf3bac86e65490e819fdf29713e701eed0448c7db6d42606bf0f7044ce6909ee052920f930bbc251999e4f74e258f1d8790e
   languageName: node
   linkType: hard
 
@@ -5750,7 +6065,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6":
+"graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.11, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: 10/bf152d0ed1dc159239db1ba1f74fdbc40cb02f626770dcd5815c427ce0688c2635a06ed69af364396da4636d0408fcf7d4afdf7881724c3307e46aff30ca49e2
@@ -5830,6 +6145,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hermes-estree@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-estree@npm:0.35.0"
+  checksum: 10/d10283d0189ab2270ecae08632ed4f15eb79f206add4960d198aa6efd5686e1c92ed37c17a020c730281e46ff2f56661f3d787bdfb1692218c1495b329049747
+  languageName: node
+  linkType: hard
+
+"hermes-parser@npm:0.35.0":
+  version: 0.35.0
+  resolution: "hermes-parser@npm:0.35.0"
+  dependencies:
+    hermes-estree: "npm:0.35.0"
+  checksum: 10/62be25fa41b708db21c4db9153b0d60cfbf9bd4645f1712eb559b3be8c191266b5b381df60fbbc45416799f73c2361eb69a81eead21dc5159fe2ea72f946d5f7
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -5888,7 +6219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^7.0.1":
+"https-proxy-agent@npm:^7.0.1, https-proxy-agent@npm:^7.0.5":
   version: 7.0.6
   resolution: "https-proxy-agent@npm:7.0.6"
   dependencies:
@@ -5943,6 +6274,17 @@ __metadata:
   version: 7.0.5
   resolution: "ignore@npm:7.0.5"
   checksum: 10/f134b96a4de0af419196f52c529d5c6120c4456ff8a6b5a14ceaaa399f883e15d58d2ce651c9b69b9388491d4669dda47285d307e827de9304a53a1824801bc6
+  languageName: node
+  linkType: hard
+
+"image-size@npm:^1.0.2":
+  version: 1.2.1
+  resolution: "image-size@npm:1.2.1"
+  dependencies:
+    queue: "npm:6.0.2"
+  bin:
+    image-size: bin/image-size.js
+  checksum: 10/b290c6cc5635565b1da51991472eb6522808430dbe3415823649723dc5f5fd8263f0f98f9bdec46184274ea24fe4f3f7a297c84b647b412e14d2208703dd8a19
   languageName: node
   linkType: hard
 
@@ -6067,6 +6409,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"invariant@npm:^2.2.4":
+  version: 2.2.4
+  resolution: "invariant@npm:2.2.4"
+  dependencies:
+    loose-envify: "npm:^1.0.0"
+  checksum: 10/cc3182d793aad82a8d1f0af697b462939cb46066ec48bbf1707c150ad5fad6406137e91a262022c269702e01621f35ef60269f6c0d7fd178487959809acdfb14
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:10.2.0":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
@@ -6151,6 +6502,13 @@ __metadata:
   version: 1.0.0
   resolution: "is-module@npm:1.0.0"
   checksum: 10/8cd5390730c7976fb4e8546dd0b38865ee6f7bacfa08dfbb2cc07219606755f0b01709d9361e01f13009bbbd8099fa2927a8ed665118a6105d66e40f1b838c3f
+  languageName: node
+  linkType: hard
+
+"is-number@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "is-number@npm:7.0.0"
+  checksum: 10/6a6c3383f68afa1e05b286af866017c78f1226d43ac8cb064e115ff9ed85eb33f5c4f7216c96a71e4dfea289ef52c5da3aef5bbfade8ffe47a0465d70c0c8e86
   languageName: node
   linkType: hard
 
@@ -6331,6 +6689,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-circus@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-circus@npm:30.4.1"
+  dependencies:
+    "@jest/environment": "npm:30.4.1"
+    "@jest/expect": "npm:30.4.1"
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    co: "npm:^4.6.0"
+    dedent: "npm:^1.6.0"
+    is-generator-fn: "npm:^2.1.0"
+    jest-each: "npm:30.4.1"
+    jest-matcher-utils: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-runtime: "npm:30.4.1"
+    jest-snapshot: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    p-limit: "npm:^3.1.0"
+    pretty-format: "npm:30.4.1"
+    pure-rand: "npm:^7.0.0"
+    slash: "npm:^3.0.0"
+    stack-utils: "npm:^2.0.6"
+  checksum: 10/768ba9d728f3daa065bfd56cbe938cfdd72065afb49002b78d767938bc8ec24a4ea68bd26236eb7d5bcf4f6194aa1e6b38671ee276b9010fbf8aeaa931448613
+  languageName: node
+  linkType: hard
+
 "jest-circus@npm:30.4.2":
   version: 30.4.2
   resolution: "jest-circus@npm:30.4.2"
@@ -6359,6 +6745,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-cli@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-cli@npm:30.4.1"
+  dependencies:
+    "@jest/core": "npm:30.4.1"
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    chalk: "npm:^4.1.2"
+    exit-x: "npm:^0.2.2"
+    import-local: "npm:^3.2.0"
+    jest-config: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    jest-validate: "npm:30.4.1"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: ./bin/jest.js
+  checksum: 10/cb1d0d4d8f99027d1f44c3529d2880ddb54014970d87d376b2305059a9a1ad67e12c9e1ffc5c092b4ce081d40dc073bee5efcfed443c782c0b65505ea295cd1d
+  languageName: node
+  linkType: hard
+
 "jest-cli@npm:30.4.2":
   version: 30.4.2
   resolution: "jest-cli@npm:30.4.2"
@@ -6381,6 +6792,48 @@ __metadata:
   bin:
     jest: ./bin/jest.js
   checksum: 10/dd33f8ee6500298639d5ec4d5f641306d9876fa182042ee40e9c63c59bdf9a82dc46da5bf38fae0783f6ac874df7f7f099006b263022954cf494f8468dfe583c
+  languageName: node
+  linkType: hard
+
+"jest-config@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-config@npm:30.4.1"
+  dependencies:
+    "@babel/core": "npm:^7.27.4"
+    "@jest/get-type": "npm:30.1.0"
+    "@jest/pattern": "npm:30.4.0"
+    "@jest/test-sequencer": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    babel-jest: "npm:30.4.1"
+    chalk: "npm:^4.1.2"
+    ci-info: "npm:^4.2.0"
+    deepmerge: "npm:^4.3.1"
+    glob: "npm:^10.5.0"
+    graceful-fs: "npm:^4.2.11"
+    jest-circus: "npm:30.4.1"
+    jest-docblock: "npm:30.4.0"
+    jest-environment-node: "npm:30.4.1"
+    jest-regex-util: "npm:30.4.0"
+    jest-resolve: "npm:30.4.1"
+    jest-runner: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    jest-validate: "npm:30.4.1"
+    parse-json: "npm:^5.2.0"
+    pretty-format: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+    strip-json-comments: "npm:^3.1.1"
+  peerDependencies:
+    "@types/node": "*"
+    esbuild-register: ">=3.4.0"
+    ts-node: ">=9.0.0"
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    esbuild-register:
+      optional: true
+    ts-node:
+      optional: true
+  checksum: 10/e04ba72a13a1e2d47f98177c94349c610444a0adc90c0a320bad92f3a1688242ae3f2760c2812e71aa8781833a6fa5be9683d79e6de9fff46cc52489f2ebb4e1
   languageName: node
   linkType: hard
 
@@ -6472,6 +6925,13 @@ __metadata:
     jest-util: "npm:30.4.1"
     jest-validate: "npm:30.4.1"
   checksum: 10/b93157061c6fa4b62808741bdda5fbc0372a9d2a3db844f0ffb819ed104b3b5c6ff73375d9f57c0d8485a0ad6aed07d4cfbb98aca985c38e1a29f64096b940bc
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^29.6.3":
+  version: 29.6.3
+  resolution: "jest-get-type@npm:29.6.3"
+  checksum: 10/88ac9102d4679d768accae29f1e75f592b760b44277df288ad76ce5bf038c3f5ce3719dea8aa0f035dac30e9eb034b848ce716b9183ad7cc222d029f03e92205
   languageName: node
   linkType: hard
 
@@ -6567,6 +7027,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-resolve-dependencies@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-resolve-dependencies@npm:30.4.1"
+  dependencies:
+    jest-regex-util: "npm:30.4.0"
+    jest-snapshot: "npm:30.4.1"
+  checksum: 10/0b757d1841ce093526ed21e363018c71f28369e2b36c54df302a40ae7d400e2a81ffd18b20c83fdeeb736cc562919cbb35e2995870089e71c38ae514468e49b2
+  languageName: node
+  linkType: hard
+
 "jest-resolve-dependencies@npm:30.4.2":
   version: 30.4.2
   resolution: "jest-resolve-dependencies@npm:30.4.2"
@@ -6590,6 +7060,36 @@ __metadata:
     slash: "npm:^3.0.0"
     unrs-resolver: "npm:^1.7.11"
   checksum: 10/197ca741df92c1006c2367142b5e44827d995f062e94a923f574e87ce04f966634851bb31f54ea377ca163a8362613947cd2311abf8a5712fe879b1ac15f662f
+  languageName: node
+  linkType: hard
+
+"jest-runner@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-runner@npm:30.4.1"
+  dependencies:
+    "@jest/console": "npm:30.4.1"
+    "@jest/environment": "npm:30.4.1"
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/transform": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    emittery: "npm:^0.13.1"
+    exit-x: "npm:^0.2.2"
+    graceful-fs: "npm:^4.2.11"
+    jest-docblock: "npm:30.4.0"
+    jest-environment-node: "npm:30.4.1"
+    jest-haste-map: "npm:30.4.1"
+    jest-leak-detector: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-resolve: "npm:30.4.1"
+    jest-runtime: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    jest-watcher: "npm:30.4.1"
+    jest-worker: "npm:30.4.1"
+    p-limit: "npm:^3.1.0"
+    source-map-support: "npm:0.5.13"
+  checksum: 10/08a9be62ef558e7f4200c755882a1e09e990ce2a23ca1756dc9ce934206d682e871d4e4bcffded09e820e98da3b59dba60ee4f9f5098e944c9178e9932a461d4
   languageName: node
   linkType: hard
 
@@ -6620,6 +7120,36 @@ __metadata:
     p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
   checksum: 10/3ed8ee70019f1f5a63faaf07a15e522ec878601dc6eccbde7eb4d0529e4d1a7314e7041160075458257e3103f41d6e9bbb2df8698806805ae2768a7e90228103
+  languageName: node
+  linkType: hard
+
+"jest-runtime@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest-runtime@npm:30.4.1"
+  dependencies:
+    "@jest/environment": "npm:30.4.1"
+    "@jest/fake-timers": "npm:30.4.1"
+    "@jest/globals": "npm:30.4.1"
+    "@jest/source-map": "npm:30.0.1"
+    "@jest/test-result": "npm:30.4.1"
+    "@jest/transform": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.1.2"
+    cjs-module-lexer: "npm:^2.1.0"
+    collect-v8-coverage: "npm:^1.0.2"
+    glob: "npm:^10.5.0"
+    graceful-fs: "npm:^4.2.11"
+    jest-haste-map: "npm:30.4.1"
+    jest-message-util: "npm:30.4.1"
+    jest-mock: "npm:30.4.1"
+    jest-regex-util: "npm:30.4.0"
+    jest-resolve: "npm:30.4.1"
+    jest-snapshot: "npm:30.4.1"
+    jest-util: "npm:30.4.1"
+    slash: "npm:^3.0.0"
+    strip-bom: "npm:^4.0.0"
+  checksum: 10/9cb033965f2e788073199abfa6991921c20c1eccff250a159967e103ac606deaf5c5c3d9c8681cf1278d0d287d2581080fefcedbdabf01d2aa6b83a77ee9fb60
   languageName: node
   linkType: hard
 
@@ -6696,6 +7226,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-util@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-util@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    "@types/node": "npm:*"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^3.2.0"
+    graceful-fs: "npm:^4.2.9"
+    picomatch: "npm:^2.2.3"
+  checksum: 10/30d58af6967e7d42bd903ccc098f3b4d3859ed46238fbc88d4add6a3f10bea00c226b93660285f058bc7a65f6f9529cf4eb80f8d4707f79f9e3a23686b4ab8f3
+  languageName: node
+  linkType: hard
+
 "jest-validate@npm:30.4.1":
   version: 30.4.1
   resolution: "jest-validate@npm:30.4.1"
@@ -6707,6 +7251,20 @@ __metadata:
     leven: "npm:^3.1.0"
     pretty-format: "npm:30.4.1"
   checksum: 10/527fe8ad02df9a4f7f467ecc4e3ac2a37a27b7b30345e7bc3cb9c2ead33fbc8ed1290c0827baa06471281012c38abb96cb268af274a0a2350548e50db20a434f
+  languageName: node
+  linkType: hard
+
+"jest-validate@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-validate@npm:29.7.0"
+  dependencies:
+    "@jest/types": "npm:^29.6.3"
+    camelcase: "npm:^6.2.0"
+    chalk: "npm:^4.0.0"
+    jest-get-type: "npm:^29.6.3"
+    leven: "npm:^3.1.0"
+    pretty-format: "npm:^29.7.0"
+  checksum: 10/8ee1163666d8eaa16d90a989edba2b4a3c8ab0ffaa95ad91b08ca42b015bfb70e164b247a5b17f9de32d096987cada63ed8491ab82761bfb9a28bc34b27ae161
   languageName: node
   linkType: hard
 
@@ -6750,6 +7308,37 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-worker@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "jest-worker@npm:29.7.0"
+  dependencies:
+    "@types/node": "npm:*"
+    jest-util: "npm:^29.7.0"
+    merge-stream: "npm:^2.0.0"
+    supports-color: "npm:^8.0.0"
+  checksum: 10/364cbaef00d8a2729fc760227ad34b5e60829e0869bd84976bdfbd8c0d0f9c2f22677b3e6dd8afa76ed174765351cd12bae3d4530c62eefb3791055127ca9745
+  languageName: node
+  linkType: hard
+
+"jest@npm:30.4.1":
+  version: 30.4.1
+  resolution: "jest@npm:30.4.1"
+  dependencies:
+    "@jest/core": "npm:30.4.1"
+    "@jest/types": "npm:30.4.1"
+    import-local: "npm:^3.2.0"
+    jest-cli: "npm:30.4.1"
+  peerDependencies:
+    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
+  peerDependenciesMeta:
+    node-notifier:
+      optional: true
+  bin:
+    jest: ./bin/jest.js
+  checksum: 10/a405ddb62f075e54120cd0aa3919c6ea98278699172d905c273324edcf68ca8ed3e8b91c6c93c6e99249468a809618160969bddbfc2dd9b182dd0908afa6818c
+  languageName: node
+  linkType: hard
+
 "jest@npm:30.4.2":
   version: 30.4.2
   resolution: "jest@npm:30.4.2"
@@ -6769,7 +7358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-tokens@npm:^4.0.0":
+"js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
   checksum: 10/af37d0d913fb56aec6dc0074c163cc71cd23c0b8aad5c2350747b6721d37ba118af35abdd8b33c47ec2800de07dedb16a527ca9c530ee004093e04958bd0cbf2
@@ -6796,6 +7385,13 @@ __metadata:
   bin:
     js-yaml: bin/js-yaml.js
   checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
+  languageName: node
+  linkType: hard
+
+"jsc-safe-url@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "jsc-safe-url@npm:0.2.4"
+  checksum: 10/2729b32e694ff7badc38ddaaf11bafa2867b3920fffa865da38c8cc84ca59a319eb681f9ba5ffba5aea942dff7850754f6b8aee01dc0f7ae8ecb1890c61d4442
   languageName: node
   linkType: hard
 
@@ -7108,6 +7704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lodash.throttle@npm:^4.1.1":
+  version: 4.1.1
+  resolution: "lodash.throttle@npm:4.1.1"
+  checksum: 10/9be9fb2ffd686c20543167883305542f4564062a5f712a40e8c6f2f0d9fd8254a6e9d801c2470b1b24e0cdf2ae83c1277b55aa0fb4799a2db6daf545f53820e1
+  languageName: node
+  linkType: hard
+
 "log-symbols@npm:4.1.0, log-symbols@npm:^4.0.0":
   version: 4.1.0
   resolution: "log-symbols@npm:4.1.0"
@@ -7115,6 +7718,17 @@ __metadata:
     chalk: "npm:^4.1.0"
     is-unicode-supported: "npm:^0.1.0"
   checksum: 10/fce1497b3135a0198803f9f07464165e9eb83ed02ceb2273930a6f8a508951178d8cf4f0378e9d28300a2ed2bc49050995d2bd5f53ab716bb15ac84d58c6ef74
+  languageName: node
+  linkType: hard
+
+"loose-envify@npm:^1.0.0":
+  version: 1.4.0
+  resolution: "loose-envify@npm:1.4.0"
+  dependencies:
+    js-tokens: "npm:^3.0.0 || ^4.0.0"
+  bin:
+    loose-envify: cli.js
+  checksum: 10/6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
   languageName: node
   linkType: hard
 
@@ -7270,6 +7884,241 @@ __metadata:
   languageName: node
   linkType: hard
 
+"metro-babel-transformer@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-babel-transformer@npm:0.83.6"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    flow-enums-runtime: "npm:^0.0.6"
+    hermes-parser: "npm:0.35.0"
+    metro-cache-key: "npm:0.83.6"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/6aa5f0edf481f4f6029f294c39383a9e0ce4d54038a92f4491cc3be2a01cb0b8e42f1c184d777b3dce47d68136c640f184b76eb1644d0fe428c1461a47db6448
+  languageName: node
+  linkType: hard
+
+"metro-cache-key@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-cache-key@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/8d1f285d6987b4e57b708272c06d30ba12bc74137c7bf8c0fbcfb61ed7855e8cd3fe7a0c4890fa6c50e63719b28bc03c1c2098a33ac8d4817687feed1521133d
+  languageName: node
+  linkType: hard
+
+"metro-cache@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-cache@npm:0.83.6"
+  dependencies:
+    exponential-backoff: "npm:^3.1.1"
+    flow-enums-runtime: "npm:^0.0.6"
+    https-proxy-agent: "npm:^7.0.5"
+    metro-core: "npm:0.83.6"
+  checksum: 10/1e2ea06528a841d478419e780fbd5eca46f1633e7b04dba59f72afa706ad74160da97d665273d6c2365eb73f3b95049b4cd1068a5594e26728941490ac13e9cf
+  languageName: node
+  linkType: hard
+
+"metro-config@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-config@npm:0.83.6"
+  dependencies:
+    connect: "npm:^3.6.5"
+    flow-enums-runtime: "npm:^0.0.6"
+    jest-validate: "npm:^29.7.0"
+    metro: "npm:0.83.6"
+    metro-cache: "npm:0.83.6"
+    metro-core: "npm:0.83.6"
+    metro-runtime: "npm:0.83.6"
+    yaml: "npm:^2.6.1"
+  checksum: 10/507b68531cf14f62827263252b10a100ab7296e13bb7dddb60a8d9d221f4d003fe704d95b59f5f0fd1701d11de453fcdf7cbf7108a1c3c0abb8ea6d1563a4533
+  languageName: node
+  linkType: hard
+
+"metro-core@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-core@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    lodash.throttle: "npm:^4.1.1"
+    metro-resolver: "npm:0.83.6"
+  checksum: 10/6ea03c09f7f894dab0f316c2238e3aa6022c2b88b84c8e6f96c66713ebf1ff02f75c2468db08bb39a7e68701e71a2c2fbd1a74600009be48d6e826202a710820
+  languageName: node
+  linkType: hard
+
+"metro-file-map@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-file-map@npm:0.83.6"
+  dependencies:
+    debug: "npm:^4.4.0"
+    fb-watchman: "npm:^2.0.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    graceful-fs: "npm:^4.2.4"
+    invariant: "npm:^2.2.4"
+    jest-worker: "npm:^29.7.0"
+    micromatch: "npm:^4.0.4"
+    nullthrows: "npm:^1.1.1"
+    walker: "npm:^1.0.7"
+  checksum: 10/5f6d74dd44f22126dd586c0f01e3e7d01f2c338bdf53d1ac984767e42c502ae3dbdfb52d550985aa58776a80dafed2e1fa5b144196dd9af27e0cdc08cf912646
+  languageName: node
+  linkType: hard
+
+"metro-minify-terser@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-minify-terser@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    terser: "npm:^5.15.0"
+  checksum: 10/36773b9127e2e99b70f7d04d03b3f50d3fec2af938088521b36ece4134d9acf23a25c95c90b9c64025d2519eeef7eb93061ff0c9e00ee2bdd25f756c67561138
+  languageName: node
+  linkType: hard
+
+"metro-resolver@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-resolver@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/fad9c8d851d529dd6520727278283e725e4ad35570beb98679481d1b1ede6d10a48c1f79aa403690f321ff8ba12399e7b1b2ebe7862d07d159e5204375a62aa0
+  languageName: node
+  linkType: hard
+
+"metro-runtime@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-runtime@npm:0.83.6"
+  dependencies:
+    "@babel/runtime": "npm:^7.25.0"
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/1a9fde73df3d8d52e7c015011a9c74fbf27aa67ebca44cce1bf12fb56b9af2d29fc8b6d5030de6a58bbb1a2797fbe1c7c8426020ac6787a273aef56ce55d6ff2
+  languageName: node
+  linkType: hard
+
+"metro-source-map@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-source-map@npm:0.83.6"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    metro-symbolicate: "npm:0.83.6"
+    nullthrows: "npm:^1.1.1"
+    ob1: "npm:0.83.6"
+    source-map: "npm:^0.5.6"
+    vlq: "npm:^1.0.0"
+  checksum: 10/983219848f04083f10a4374400d76a124aa364056f7b7e428ffae4ebda8c3867614c9866309d633ef67e1fba92f52f866de1cfe86b8e9cc29873f92186a4f58f
+  languageName: node
+  linkType: hard
+
+"metro-symbolicate@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-symbolicate@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+    invariant: "npm:^2.2.4"
+    metro-source-map: "npm:0.83.6"
+    nullthrows: "npm:^1.1.1"
+    source-map: "npm:^0.5.6"
+    vlq: "npm:^1.0.0"
+  bin:
+    metro-symbolicate: src/index.js
+  checksum: 10/a94325c1893312671091eac90ea4419d4b555d0a5f163524c8a7f7eabf4219508944dee5107ae4c519ef8266525632a54e9557c0142d94b2097378c7580a9108
+  languageName: node
+  linkType: hard
+
+"metro-transform-plugins@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-transform-plugins@npm:0.83.6"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/257f6fffa63e2d436033fb4d0f17e7200b43bad1dcc8da7ff7a5fed6cd00a60a14e5687a6330522773ffbc5c90f81c038e57105ee80313100fbcd6945275a687
+  languageName: node
+  linkType: hard
+
+"metro-transform-worker@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro-transform-worker@npm:0.83.6"
+  dependencies:
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    flow-enums-runtime: "npm:^0.0.6"
+    metro: "npm:0.83.6"
+    metro-babel-transformer: "npm:0.83.6"
+    metro-cache: "npm:0.83.6"
+    metro-cache-key: "npm:0.83.6"
+    metro-minify-terser: "npm:0.83.6"
+    metro-source-map: "npm:0.83.6"
+    metro-transform-plugins: "npm:0.83.6"
+    nullthrows: "npm:^1.1.1"
+  checksum: 10/0d8c59fef2a880f060b59fbda0568214bc3290c5e1795a759404e53e97b1ec7b71e55b89a2e25e44337ee49a4e7f0ed1a7c7d788a203ecad48b77fabd8023331
+  languageName: node
+  linkType: hard
+
+"metro@npm:0.83.6":
+  version: 0.83.6
+  resolution: "metro@npm:0.83.6"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.0"
+    "@babel/core": "npm:^7.25.2"
+    "@babel/generator": "npm:^7.29.1"
+    "@babel/parser": "npm:^7.29.0"
+    "@babel/template": "npm:^7.28.6"
+    "@babel/traverse": "npm:^7.29.0"
+    "@babel/types": "npm:^7.29.0"
+    accepts: "npm:^2.0.0"
+    chalk: "npm:^4.0.0"
+    ci-info: "npm:^2.0.0"
+    connect: "npm:^3.6.5"
+    debug: "npm:^4.4.0"
+    error-stack-parser: "npm:^2.0.6"
+    flow-enums-runtime: "npm:^0.0.6"
+    graceful-fs: "npm:^4.2.4"
+    hermes-parser: "npm:0.35.0"
+    image-size: "npm:^1.0.2"
+    invariant: "npm:^2.2.4"
+    jest-worker: "npm:^29.7.0"
+    jsc-safe-url: "npm:^0.2.2"
+    lodash.throttle: "npm:^4.1.1"
+    metro-babel-transformer: "npm:0.83.6"
+    metro-cache: "npm:0.83.6"
+    metro-cache-key: "npm:0.83.6"
+    metro-config: "npm:0.83.6"
+    metro-core: "npm:0.83.6"
+    metro-file-map: "npm:0.83.6"
+    metro-resolver: "npm:0.83.6"
+    metro-runtime: "npm:0.83.6"
+    metro-source-map: "npm:0.83.6"
+    metro-symbolicate: "npm:0.83.6"
+    metro-transform-plugins: "npm:0.83.6"
+    metro-transform-worker: "npm:0.83.6"
+    mime-types: "npm:^3.0.1"
+    nullthrows: "npm:^1.1.1"
+    serialize-error: "npm:^2.1.0"
+    source-map: "npm:^0.5.6"
+    throat: "npm:^5.0.0"
+    ws: "npm:^7.5.10"
+    yargs: "npm:^17.6.2"
+  bin:
+    metro: src/cli.js
+  checksum: 10/37b97fb2b99fbb2c9d347664d663f64a54219650c0e59e1c12a95e938c33557795c6de26a95ea890239e3d70efd287b815727ce1616aba317d17ec8450c650a4
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.4":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
+  dependencies:
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10/6bf2a01672e7965eb9941d1f02044fad2bd12486b5553dc1116ff24c09a8723157601dc992e74c911d896175918448762df3b3fd0a6b61037dd1a9766ddfbf58
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:1.52.0":
   version: 1.52.0
   resolution: "mime-db@npm:1.52.0"
@@ -7290,6 +8139,15 @@ __metadata:
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10/89aa9651b67644035de2784a6e665fc685d79aba61857e02b9c8758da874a754aed4a9aced9265f5ed1171fd934331e5516b84a7f0218031b6fa0270eca1e51a
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10/9db0ad31f5eff10ee8f848130779b7f2d056ddfdb6bda696cb69be68d486d33a3457b4f3f9bdeb60d0736edb471bd5a7c0a384375c011c51c889fd0d5c3b893e
   languageName: node
   linkType: hard
 
@@ -7441,6 +8299,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ms@npm:2.0.0":
+  version: 2.0.0
+  resolution: "ms@npm:2.0.0"
+  checksum: 10/0e6a22b8b746d2e0b65a430519934fefd41b6db0682e3477c10f60c76e947c4c0ad06f63ffdf1d78d335f83edee8c0aa928aa66a36c7cd95b69b26f468d527f4
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -7482,6 +8347,20 @@ __metadata:
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: 10/1a7948fea86f2b33ec766bc899c88796a51ba76a4afc9026764aedc6e7cde692a09067031e4a1bf6db4f978ccd99e7f5b6c03fe47ad9865c3d4f99050d67e002
+  languageName: node
+  linkType: hard
+
+"node-fetch@npm:^2.7.0":
+  version: 2.7.0
+  resolution: "node-fetch@npm:2.7.0"
+  dependencies:
+    whatwg-url: "npm:^5.0.0"
+  peerDependencies:
+    encoding: ^0.1.0
+  peerDependenciesMeta:
+    encoding:
+      optional: true
+  checksum: 10/b24f8a3dc937f388192e59bcf9d0857d7b6940a2496f328381641cb616efccc9866e89ec43f2ec956bbd6c3d3ee05524ce77fe7b29ccd34692b3a16f237d6676
   languageName: node
   linkType: hard
 
@@ -7743,6 +8622,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nullthrows@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "nullthrows@npm:1.1.1"
+  checksum: 10/c7cf377a095535dc301d81cf7959d3784d090a609a2a4faa40b6121a0c1d7f70d3a3aa534a34ab852e8553b66848ec503c28f2c19efd617ed564dc07dfbb6d33
+  languageName: node
+  linkType: hard
+
 "nx@npm:>=21.5.3 < 23.0.0":
   version: 22.7.1
   resolution: "nx@npm:22.7.1"
@@ -7900,6 +8786,24 @@ __metadata:
     nx: dist/bin/nx.js
     nx-cloud: dist/bin/nx-cloud.js
   checksum: 10/965fb8e376b10ebdaf495ae35e6b6d19a5e383d28f849e0c304954cd89320979a4588eeab841ae0adbb66c9a9e6a034290d992cb47cd055496d4554954d46d03
+  languageName: node
+  linkType: hard
+
+"ob1@npm:0.83.6":
+  version: 0.83.6
+  resolution: "ob1@npm:0.83.6"
+  dependencies:
+    flow-enums-runtime: "npm:^0.0.6"
+  checksum: 10/817cc83247508f6a17641924af5ccd793535e9376442ab8f9e59f7070cfb4830269540cacf79d036cdf087585810ced7dae3ea213c7f2dad73c2f198f1b676f9
+  languageName: node
+  linkType: hard
+
+"on-finished@npm:~2.3.0":
+  version: 2.3.0
+  resolution: "on-finished@npm:2.3.0"
+  dependencies:
+    ee-first: "npm:1.1.1"
+  checksum: 10/1db595bd963b0124d6fa261d18320422407b8f01dc65863840f3ddaaf7bcad5b28ff6847286703ca53f4ec19595bd67a2f1253db79fc4094911ec6aa8df1671b
   languageName: node
   linkType: hard
 
@@ -8200,6 +9104,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parseurl@npm:~1.3.3":
+  version: 1.3.3
+  resolution: "parseurl@npm:1.3.3"
+  checksum: 10/407cee8e0a3a4c5cd472559bca8b6a45b82c124e9a4703302326e9ab60fc1081442ada4e02628efef1eb16197ddc7f8822f5a91fd7d7c86b51f530aedb17dfa2
+  languageName: node
+  linkType: hard
+
 "path-exists@npm:^3.0.0":
   version: 3.0.0
   resolution: "path-exists@npm:3.0.0"
@@ -8271,7 +9182,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^2.0.4":
+"picomatch@npm:^2.0.4, picomatch@npm:^2.2.3, picomatch@npm:^2.3.1":
   version: 2.3.2
   resolution: "picomatch@npm:2.3.2"
   checksum: 10/b788ef8148a2415b9dec12f0bb350ae6a5830f8f1950e472abc2f5225494debf7d1b75eb031df0ceaea9e8ec3e7bad599e8dbf3c60d61b42be429ba41bff4426
@@ -8334,6 +9245,17 @@ __metadata:
     react-is-18: "npm:react-is@^18.3.1"
     react-is-19: "npm:react-is@^19.2.5"
   checksum: 10/60311ef47a646eeaec0432efe66290cb6f0d2eccb123a28ad4ab6d7e53087bc62db91cfd54c3cc00c89d6875aefb2bf6264381b6c9411ce6bff3d6aa8280abad
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^29.7.0":
+  version: 29.7.0
+  resolution: "pretty-format@npm:29.7.0"
+  dependencies:
+    "@jest/schemas": "npm:^29.6.3"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^18.0.0"
+  checksum: 10/dea96bc83c83cd91b2bfc55757b6b2747edcaac45b568e46de29deee80742f17bc76fe8898135a70d904f4928eafd8bb693cd1da4896e8bdd3c5e82cadf1d2bb
   languageName: node
   linkType: hard
 
@@ -8419,6 +9341,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"queue@npm:6.0.2":
+  version: 6.0.2
+  resolution: "queue@npm:6.0.2"
+  dependencies:
+    inherits: "npm:~2.0.3"
+  checksum: 10/3437954ef1442c86ff01a0fbe3dc6222838823b1ca97f37eff651bc20b868c0c2904424ef2c0d44cba46055f54b578f92866e573125dc9a5e8823d751e4d1585
+  languageName: node
+  linkType: hard
+
 "quick-lru@npm:^4.0.1":
   version: 4.0.1
   resolution: "quick-lru@npm:4.0.1"
@@ -8426,7 +9357,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is-18@npm:react-is@^18.3.1":
+"react-is-18@npm:react-is@^18.3.1, react-is@npm:^18.0.0":
   version: 18.3.1
   resolution: "react-is@npm:18.3.1"
   checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
@@ -8864,6 +9795,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"serialize-error@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "serialize-error@npm:2.1.0"
+  checksum: 10/28464a6f65e6becd6e49fb782aff06573fdbf3d19f161a20228179842fed05c75a34110e54c3ee020b00240f9e11d8bee9b9fee5d04e0bc0bef1fdbf2baa297e
+  languageName: node
+  linkType: hard
+
 "shebang-command@npm:^2.0.0":
   version: 2.0.0
   resolution: "shebang-command@npm:2.0.0"
@@ -8970,10 +9908,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "source-map@npm:0.5.7"
+  checksum: 10/9b4ac749ec5b5831cad1f8cc4c19c4298ebc7474b24a0acf293e2f040f03f8eeccb3d01f12aa0f90cf46d555c887e03912b83a042c627f419bda5152d89c5269
+  languageName: node
+  linkType: hard
+
 "source-map@npm:^0.6.0, source-map@npm:^0.6.1":
   version: 0.6.1
   resolution: "source-map@npm:0.6.1"
   checksum: 10/59ef7462f1c29d502b3057e822cdbdae0b0e565302c4dd1a95e11e793d8d9d62006cdc10e0fd99163ca33ff2071360cf50ee13f90440806e7ed57d81cba2f7ff
+  languageName: node
+  linkType: hard
+
+"source-map@npm:^0.7.4":
+  version: 0.7.6
+  resolution: "source-map@npm:0.7.6"
+  checksum: 10/c8d2da7c57c14f3fd7568f764b39ad49bbf9dd7632b86df3542b31fed117d4af2fb74a4f886fc06baf7a510fee68e37998efc3080aacdac951c36211dc29a7a3
   languageName: node
   linkType: hard
 
@@ -9070,6 +10022,20 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^2.0.0"
   checksum: 10/cdc988acbc99075b4b036ac6014e5f1e9afa7e564482b687da6384eee6a1909d7eaffde85b0a17ffbe186c5247faf6c2b7544e802109f63b72c7be69b13151bb
+  languageName: node
+  linkType: hard
+
+"stackframe@npm:^1.3.4":
+  version: 1.3.4
+  resolution: "stackframe@npm:1.3.4"
+  checksum: 10/29ca71c1fd17974c1c178df0236b1407bc65f6ea389cc43dec000def6e42ff548d4453de9a85b76469e2ae2b2abdd802c6b6f3db947c05794efbd740d1cf4121
+  languageName: node
+  linkType: hard
+
+"statuses@npm:~1.5.0":
+  version: 1.5.0
+  resolution: "statuses@npm:1.5.0"
+  checksum: 10/c469b9519de16a4bb19600205cffb39ee471a5f17b82589757ca7bd40a8d92ebb6ed9f98b5a540c5d302ccbc78f15dc03cc0280dd6e00df1335568a5d5758a5c
   languageName: node
   linkType: hard
 
@@ -9297,7 +10263,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"terser@npm:^5.31.1":
+"terser@npm:^5.15.0, terser@npm:^5.31.1":
   version: 5.47.1
   resolution: "terser@npm:5.47.1"
   dependencies:
@@ -9326,6 +10292,13 @@ __metadata:
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
   checksum: 10/56a9962c1b62d39b2bcb369b7558ca85c1b55e554b38dfd725edcc0a1babe5815782a60c17ff6b839093b163dfebb92b804208aaaea616ec7571c8059ae0cf44
+  languageName: node
+  linkType: hard
+
+"throat@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "throat@npm:5.0.0"
+  checksum: 10/00f7197977d433d1c960edfaa6465c1217652999170ef3ecd8dbefa6add6e2304b321480523ae87354df285474ba2c5feff03842e9f398b4bcdd95cfa18cff9c
   languageName: node
   linkType: hard
 
@@ -9377,6 +10350,22 @@ __metadata:
   version: 1.0.5
   resolution: "tmpl@npm:1.0.5"
   checksum: 10/cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
+  languageName: node
+  linkType: hard
+
+"to-regex-range@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "to-regex-range@npm:5.0.1"
+  dependencies:
+    is-number: "npm:^7.0.0"
+  checksum: 10/10dda13571e1f5ad37546827e9b6d4252d2e0bc176c24a101252153ef435d83696e2557fe128c4678e4e78f5f01e83711c703eef9814eb12dab028580d45980a
+  languageName: node
+  linkType: hard
+
+"tr46@npm:~0.0.3":
+  version: 0.0.3
+  resolution: "tr46@npm:0.0.3"
+  checksum: 10/8f1f5aa6cb232f9e1bdc86f485f916b7aa38caee8a778b378ffec0b70d9307873f253f5cbadbe2955ece2ac5c83d0dc14a77513166ccd0a0c7fe197e21396695
   languageName: node
   linkType: hard
 
@@ -9630,6 +10619,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"unpipe@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "unpipe@npm:1.0.0"
+  checksum: 10/4fa18d8d8d977c55cb09715385c203197105e10a6d220087ec819f50cb68870f02942244f1017565484237f1f8c5d3cd413631b1ae104d3096f24fdfde1b4aa2
+  languageName: node
+  linkType: hard
+
 "unrs-resolver@npm:^1.7.11":
   version: 1.11.1
   resolution: "unrs-resolver@npm:1.11.1"
@@ -9725,6 +10721,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"utils-merge@npm:1.0.1":
+  version: 1.0.1
+  resolution: "utils-merge@npm:1.0.1"
+  checksum: 10/5d6949693d58cb2e636a84f3ee1c6e7b2f9c16cb1d42d0ecb386d8c025c69e327205aa1c69e2868cc06a01e5e20681fbba55a4e0ed0cce913d60334024eae798
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -9760,6 +10763,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vlq@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "vlq@npm:1.0.1"
+  checksum: 10/0f4270cb3c498077a7ddd343e07ea164ac65cf05f3efd4332948fcb3d48e655538558e3fcdca7c78bb3c6790e0ef43c953efc7d9256c50415c3a5313f1e4192c
+  languageName: node
+  linkType: hard
+
 "walk-up-path@npm:^4.0.0":
   version: 4.0.0
   resolution: "walk-up-path@npm:4.0.0"
@@ -9767,7 +10777,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"walker@npm:^1.0.8":
+"walker@npm:^1.0.7, walker@npm:^1.0.8":
   version: 1.0.8
   resolution: "walker@npm:1.0.8"
   dependencies:
@@ -9792,6 +10802,13 @@ __metadata:
   dependencies:
     defaults: "npm:^1.0.3"
   checksum: 10/182ebac8ca0b96845fae6ef44afd4619df6987fe5cf552fdee8396d3daa1fb9b8ec5c6c69855acb7b3c1231571393bd1f0a4cdc4028d421575348f64bb0a8817
+  languageName: node
+  linkType: hard
+
+"webidl-conversions@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "webidl-conversions@npm:3.0.1"
+  checksum: 10/b65b9f8d6854572a84a5c69615152b63371395f0c5dcd6729c45789052296df54314db2bc3e977df41705eacb8bc79c247cee139a63fa695192f95816ed528ad
   languageName: node
   linkType: hard
 
@@ -9836,6 +10853,16 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: 10/524dcd7f07dfa993ab46c5ae2e302aeaa98bed760e40644f61544c1db67e5cd7be24016c8ee245895eda024020cfa58a953f1771a21028ac5d040adc92240e0f
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-url@npm:5.0.0"
+  dependencies:
+    tr46: "npm:~0.0.3"
+    webidl-conversions: "npm:^3.0.0"
+  checksum: 10/f95adbc1e80820828b45cc671d97da7cd5e4ef9deb426c31bcd5ab00dc7103042291613b3ef3caec0a2335ed09e0d5ed026c940755dbb6d404e2b27f940fdf07
   languageName: node
   linkType: hard
 
@@ -9948,6 +10975,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ws@npm:^7.5.10":
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/9c796b84ba80ffc2c2adcdfc9c8e9a219ba99caa435c9a8d45f9ac593bba325563b3f83edc5eb067cc6d21b9a6bf2c930adf76dd40af5f58a5ca6859e81858f0
+  languageName: node
+  linkType: hard
+
 "xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
@@ -9992,6 +11034,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"yaml@npm:^2.6.1":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
+  bin:
+    yaml: bin.mjs
+  checksum: 10/9a95e8e08651c3d292ab6a5befeb5f57b76801caa097c75bb45c9a70ce19c1b11f57e87a6ef84a579ea070ed2c2c8ac541c88c0ae684d544d5f42c7e77d11b7b
+  languageName: node
+  linkType: hard
+
 "yargs-parser@npm:21.1.1, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
@@ -10006,7 +11057,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.7.2":
+"yargs@npm:17.7.2, yargs@npm:^17.6.2, yargs@npm:^17.7.2":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
## Summary

Adds **`@grafana/faro-metro-plugin`**: Metro integration for React Native so release/Hermes bundles get a Faro-compatible source map shape, an injectable **`FARO_BUNDLE_ID` / `__faroBundleId_<appName>`** preamble, and tooling to upload the **composed** Hermes source map via **`faro-cli metro upload`** (CLI + optional Gradle shim + upload script entrypoint).

Supersedes/extends earlier “symbolification” sketch in the PR; includes follow-ups from **`#546`** (Hermes-flat map emission for frame resolution), Gradle/source-map upload wiring, docs, tests, and a **dependency alignment fix** so Jest 30 stays consistent across workspaces (CI-stable `yarn test` / `yarn build`).

## What ships

### New package: `@grafana/faro-metro-plugin`

- **`withFaroConfig` / Metro serializer** plumbing to emit maps and bundle preamble aligned with Grafana Frontend Observability + Hermes pipelines.
- **Hermes-aware map helpers** (`flattenMapForHermes`, `shiftSourceMap`, `serialize`, bundle id resolution, Metro dependency wiring).
- **`bin/faro-upload-source-map.js`** — shim to **`faro-cli metro upload`** so native/Gradle callers don’t depend on CLI hoisting.
- **`android/source-map-upload.gradle`** — optional/advanced manual Gradle hook for apps **not** using autolinking from the RN SDK.
- README, changelog, rollup build, tests (including fixture maps for Path A release).

### `@grafana/faro-cli`

- **`metro`** subcommand / Metro upload entrypoint (**`metro.ts`**), **`cli.ts`** wiring, README updates.
- Unit tests (**`metro.test.ts`**).

### `@grafana/faro-bundlers-shared`

- Shared utilities / types used by Metro + preamble behavior; tests expanded.

### Monorepo / CI hygiene

- **`yarn.lock`** and package updates (including **Webpack Jest deps** lined up with the rest of the repo) after merge/rebase churn so **`lerna run test`** stays green.

### Docs & tests elsewhere

- Root **`README.md`** (package listing / high-level Metro mention as appropriate).
- Adjustments in **`faro-esbuild` / `faro-rollup`** tests where shared behavior or mocks shifted.

## Reviewer hints

- **End-to-end story**: Metro plugin + composed map upload + preamble ↔ **`meta.app.bundleId`** on device ↔ FE O11y ingest (same mental model as the architecture diagram attached in the discussion thread).

**Related diagram (from PR discussion):**

![Symbolification React Native - Architecture](https://github.com/user-attachments/assets/eecf9c20-8d9c-4a72-8219-03c3dff3fe6a)

<img width="3000" height="2191" alt="Symbolification React Native - Architecture" src="https://github.com/user-attachments/assets/eecf9c20-8d9c-4a72-8219-03c3dff3fe6a" />
