### PR TITLE
fix(metro-plugin): emit Hermes-flat source map so frames resolve

### DIFF
--- a/packages/faro-metro-plugin/src/flattenMapForHermes.ts
+++ b/packages/faro-metro-plugin/src/flattenMapForHermes.ts
@@ -1,33 +1,74 @@
 import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
 
 /**
- * Rewrite `mapJson` so every mapping is on generated line 1, with `column` set to the
- * absolute byte offset of that mapping's position in `bundleCode`.
+ * Walk `s` once and build:
+ *   - `lineStartUtf16[i]`: UTF-16 code unit index of line (i+1)'s first character.
+ *   - `utf16ToUtf8[i]`: UTF-8 byte offset of the position that UTF-16 code unit `i` represents.
  *
- * Hermes stack frames are reported as `(line=1, column=<byte offset into the JS bundle>)`
- * regardless of newlines in the source. Standard Metro source maps key mappings by
- * `(generatedLine, generatedColumn)` where line is newline-counted, so a receiver looking
- * up `(1, byteOffset)` against an un-flattened map misses everything past the first line.
+ * Used to translate a Metro source map's `(generatedLine, generatedColumn)` — where
+ * columns are 0-based UTF-16 code unit indices per the source-map spec — into the
+ * UTF-8 byte offsets Hermes uses for stack frame columns. For an all-ASCII bundle the
+ * two tables collapse to a single line-start array; the bookkeeping only matters once
+ * the bundle contains non-Latin string literals, emoji, or other multi-byte content.
+ */
+function buildOffsetTables(s: string): { lineStartUtf16: number[]; utf16ToUtf8: number[] } {
+  const lineStartUtf16: number[] = [0];
+  const utf16ToUtf8: number[] = new Array(s.length + 1);
+  let utf8 = 0;
+  let i = 0;
+  while (i < s.length) {
+    utf16ToUtf8[i] = utf8;
+    const c = s.charCodeAt(i);
+    if (c === 0x0a) {
+      utf8 += 1;
+      i += 1;
+      lineStartUtf16.push(i);
+    } else if (c < 0x80) {
+      utf8 += 1;
+      i += 1;
+    } else if (c < 0x800) {
+      utf8 += 2;
+      i += 1;
+    } else if (c >= 0xd800 && c <= 0xdbff && i + 1 < s.length) {
+      // High surrogate paired with a following low surrogate encodes one Unicode
+      // codepoint in 4 UTF-8 bytes. Record the byte offset for the low surrogate's
+      // position too so columns landing on either half resolve identically.
+      utf16ToUtf8[i + 1] = utf8;
+      utf8 += 4;
+      i += 2;
+    } else {
+      utf8 += 3;
+      i += 1;
+    }
+  }
+  utf16ToUtf8[s.length] = utf8;
+  return { lineStartUtf16, utf16ToUtf8 };
+}
+
+/**
+ * Rewrite `mapJson` so every mapping is on generated line 1, with `column` set to the
+ * absolute UTF-8 byte offset of that mapping's position in `bundleCode`.
+ *
+ * Hermes stack frames are reported as `(line=1, column=<UTF-8 byte offset>)` regardless
+ * of newlines in the source. Standard Metro source maps key mappings by
+ * `(generatedLine, generatedColumn)` where line is newline-counted and column is a
+ * UTF-16 code unit index (per the source-map spec). Without this rewrite, a receiver
+ * looking up `(1, byteOffset)` against an un-flattened map misses everything past the
+ * first line; with non-ASCII content in the bundle, raw UTF-16 indices would also
+ * drift from Hermes' byte offsets.
  *
  * Assumes `mapJson` describes the original code Metro produced (pre-preamble) and
- * `bundleCode` is the final bundle (`${preamble}\n${code}` as composed in `serialize.ts`).
- * `preambleLines` is the number of bundle lines the preamble occupies before the original
- * code starts — the default of 1 matches the snippet+newline pattern emitted by
- * `createFaroMetroCustomSerializer`.
+ * `bundleCode` is the final bundle (`${preamble}\n${code}` as composed in
+ * `serialize.ts`). `preambleLines` is the number of bundle lines the preamble occupies
+ * before the original code starts — the default of 1 matches the snippet+newline
+ * pattern emitted by `createFaroMetroCustomSerializer`.
  */
 export async function flattenMapForHermes(
   mapJson: Record<string, unknown>,
   bundleCode: string,
   preambleLines = 1
 ): Promise<Record<string, unknown>> {
-  // Byte offset of the start of each line in the final bundle. lineStart[i] is the
-  // start of bundle line i+1 (0-indexed array); lineStart[0] is always 0.
-  const lineStart: number[] = [0];
-  for (let i = 0; i < bundleCode.length; i++) {
-    if (bundleCode.charCodeAt(i) === 10) {
-      lineStart.push(i + 1);
-    }
-  }
+  const { lineStartUtf16, utf16ToUtf8 } = buildOffsetTables(bundleCode);
 
   const asInput = mapJson as unknown as Parameters<typeof SourceMapConsumer.with>[0];
 
@@ -41,11 +82,16 @@ export async function flattenMapForHermes(
       if (m.source == null) {
         return;
       }
-      // Original code line L lives on bundle line L + preambleLines; lineStart is
-      // 0-indexed so the byte offset of that line's start is at index
-      // (preambleLines + L - 1). Clamp to the table to be defensive.
-      const idx = Math.min(preambleLines + m.generatedLine - 1, lineStart.length - 1);
-      const absoluteCol = lineStart[idx] + m.generatedColumn;
+      // Original code line L lives on bundle line L + preambleLines. `lineStartUtf16`
+      // is 0-indexed; the UTF-16 start of that bundle line is at index
+      // (preambleLines + L - 1). Clamp to the table to be defensive against malformed
+      // or trailing mappings that reference a line past the bundle's end.
+      const lineIdx = Math.min(preambleLines + m.generatedLine - 1, lineStartUtf16.length - 1);
+      const utf16Pos = Math.min(
+        lineStartUtf16[lineIdx] + m.generatedColumn,
+        utf16ToUtf8.length - 1
+      );
+      const absoluteCol = utf16ToUtf8[utf16Pos];
       generator.addMapping({
         generated: { line: 1, column: absoluteCol },
         original: {
@@ -58,7 +104,10 @@ export async function flattenMapForHermes(
     });
 
     for (const source of consumer.sources) {
-      const content = consumer.sourceContentFor(source);
+      // Pass `nullOnMissing=true` so sources without embedded content return `null`
+      // instead of throwing — Metro can emit maps with partial `sourcesContent`, and
+      // we want those to flatten without aborting.
+      const content = consumer.sourceContentFor(source, true);
       if (content !== null) {
         generator.setSourceContent(source, content);
       }

--- a/packages/faro-metro-plugin/src/flattenMapForHermes.ts
+++ b/packages/faro-metro-plugin/src/flattenMapForHermes.ts
@@ -1,0 +1,69 @@
+import { SourceMapConsumer, SourceMapGenerator } from 'source-map';
+
+/**
+ * Rewrite `mapJson` so every mapping is on generated line 1, with `column` set to the
+ * absolute byte offset of that mapping's position in `bundleCode`.
+ *
+ * Hermes stack frames are reported as `(line=1, column=<byte offset into the JS bundle>)`
+ * regardless of newlines in the source. Standard Metro source maps key mappings by
+ * `(generatedLine, generatedColumn)` where line is newline-counted, so a receiver looking
+ * up `(1, byteOffset)` against an un-flattened map misses everything past the first line.
+ *
+ * Assumes `mapJson` describes the original code Metro produced (pre-preamble) and
+ * `bundleCode` is the final bundle (`${preamble}\n${code}` as composed in `serialize.ts`).
+ * `preambleLines` is the number of bundle lines the preamble occupies before the original
+ * code starts — the default of 1 matches the snippet+newline pattern emitted by
+ * `createFaroMetroCustomSerializer`.
+ */
+export async function flattenMapForHermes(
+  mapJson: Record<string, unknown>,
+  bundleCode: string,
+  preambleLines = 1
+): Promise<Record<string, unknown>> {
+  // Byte offset of the start of each line in the final bundle. lineStart[i] is the
+  // start of bundle line i+1 (0-indexed array); lineStart[0] is always 0.
+  const lineStart: number[] = [0];
+  for (let i = 0; i < bundleCode.length; i++) {
+    if (bundleCode.charCodeAt(i) === 10) {
+      lineStart.push(i + 1);
+    }
+  }
+
+  const asInput = mapJson as unknown as Parameters<typeof SourceMapConsumer.with>[0];
+
+  return SourceMapConsumer.with(asInput, null, async (consumer) => {
+    const generator = new SourceMapGenerator({
+      file: mapJson.file as string | undefined,
+      sourceRoot: mapJson.sourceRoot as string | undefined,
+    });
+
+    consumer.eachMapping((m) => {
+      if (m.source == null) {
+        return;
+      }
+      // Original code line L lives on bundle line L + preambleLines; lineStart is
+      // 0-indexed so the byte offset of that line's start is at index
+      // (preambleLines + L - 1). Clamp to the table to be defensive.
+      const idx = Math.min(preambleLines + m.generatedLine - 1, lineStart.length - 1);
+      const absoluteCol = lineStart[idx] + m.generatedColumn;
+      generator.addMapping({
+        generated: { line: 1, column: absoluteCol },
+        original: {
+          line: m.originalLine ?? 1,
+          column: m.originalColumn ?? 0,
+        },
+        source: m.source,
+        name: m.name ?? undefined,
+      });
+    });
+
+    for (const source of consumer.sources) {
+      const content = consumer.sourceContentFor(source);
+      if (content !== null) {
+        generator.setSourceContent(source, content);
+      }
+    }
+
+    return generator.toJSON() as unknown as Record<string, unknown>;
+  });
+}

--- a/packages/faro-metro-plugin/src/index.ts
+++ b/packages/faro-metro-plugin/src/index.ts
@@ -33,4 +33,5 @@ export default function withFaroConfig(
 
 export { createFaroMetroCustomSerializer, computeSkipUpload, getSortedModules } from './serialize';
 export { shiftGeneratedLineNumbers } from './shiftSourceMap';
+export { flattenMapForHermes } from './flattenMapForHermes';
 export { normalizeBundleIdLength, resolveBundleId } from './resolveBundleId';

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -14,6 +14,7 @@ import {
   type FaroSourceMapUploaderPluginOptions,
 } from '@grafana/faro-bundlers-shared';
 import { shiftGeneratedLineNumbers } from './shiftSourceMap';
+import { flattenMapForHermes } from './flattenMapForHermes';
 import { resolveBundleId } from './resolveBundleId';
 import { loadMetroDeps } from './metroDeps';
 
@@ -26,6 +27,15 @@ export type FaroMetroPluginOptions = FaroSourceMapUploaderPluginOptions & {
    * Defaults from the temporary map basename. Align with `releaseBundleFilename` in `@grafana/faro-react-native` if you change it.
    */
   sourceMapFile?: string;
+  /**
+   * Emit a Hermes-compatible "flat" source map where every mapping lives on generated
+   * line 1 with `column` set to the absolute byte offset in the JS bundle. Hermes stack
+   * frames always report `line=1, column=<byte offset>`, so a normal multi-line generated
+   * map can't be looked up by the receiver. Defaults to `true` (Hermes is the default
+   * runtime in modern React Native). Set `false` for JSC-only builds, which will fall
+   * back to the legacy `+1` line shift.
+   */
+  hermes?: boolean;
 };
 
 export type MetroCustomSerializer = (
@@ -206,12 +216,15 @@ export function createFaroMetroCustomSerializer(
     const newCode = `${snippet}\n${code}`;
 
     const mapObj = JSON.parse(map) as Record<string, unknown>;
-    const shifted = await shiftGeneratedLineNumbers(mapObj, 1);
+    const useHermes = pluginOptions.hermes !== false;
+    const rewritten = useHermes
+      ? await flattenMapForHermes(mapObj, newCode, 1)
+      : await shiftGeneratedLineNumbers(mapObj, 1);
     const mapFileBase = (pluginOptions.sourceMapFile ?? 'bundle.js').replace(/\.map$/i, '');
-    if (shifted.file == null || shifted.file === '') {
-      shifted.file = mapFileBase;
+    if (rewritten.file == null || rewritten.file === '') {
+      rewritten.file = mapFileBase;
     }
-    const mapOut = JSON.stringify(shifted);
+    const mapOut = JSON.stringify(rewritten);
 
     if (!skip && !bundleDev) {
       await maybeUploadMap(mapOut, bundleId, pluginOptions, bundleDev);

--- a/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
+++ b/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
@@ -121,6 +121,78 @@ describe('flattenMapForHermes', () => {
     });
   });
 
+  test('encodes non-ASCII bundle content as UTF-8 byte offsets', async () => {
+    // Original code (what the map describes):
+    //   line 1 in UTF-16: "ñAB"  (3 code units: ñ=1, A=1, B=1)
+    //   line 1 in UTF-8 : "ñAB"  (4 bytes:     ñ=2, A=1, B=1)
+    // Map mapping at (generatedLine=1, generatedColumn=1) sits **after** ñ.
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0], // before ñ
+      [1, 1, 'a.ts', 1, 5], // after ñ — UTF-16 col=1, UTF-8 byte offset relative to line start=2
+    ]);
+
+    // Final bundle = "X\n" (preamble, 2 UTF-8 bytes) + "ñAB" → 6 UTF-8 bytes total.
+    //   byte 0..0 = 'X', byte 1 = '\n', byte 2..3 = 'ñ', byte 4 = 'A', byte 5 = 'B'.
+    const bundleCode = 'X\nñAB';
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // mapping (1, 0) → bundle byte 2 (before ñ)
+    expect(consumer.originalPositionFor({ line: 1, column: 2 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    // mapping (1, 1) → bundle byte 4 (after ñ; would be byte 3 if we (wrongly) used UTF-16 cols)
+    expect(consumer.originalPositionFor({ line: 1, column: 4 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 5,
+    });
+  });
+
+  test('handles 4-byte UTF-8 sequences (surrogate pairs / emoji)', async () => {
+    // '🎉' (U+1F389) is a single Unicode codepoint encoded as a UTF-16 surrogate pair
+    // (2 code units) and 4 UTF-8 bytes. After it, an ASCII char should be at byte 4.
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0], // before emoji
+      [1, 2, 'a.ts', 1, 9], // after emoji — UTF-16 col=2 (past the surrogate pair), UTF-8 offset=4
+    ]);
+
+    const bundleCode = '\n🎉Z'; // preamble line 1 is empty, original code is line 2
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // Bundle byte layout: \n(1) + 🎉(4 bytes) + Z(1) → emoji starts at byte 1, Z at byte 5.
+    expect(consumer.originalPositionFor({ line: 1, column: 1 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 5 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 9,
+    });
+  });
+
+  test('tolerates sources without sourcesContent (does not throw)', async () => {
+    // Build a map with a `sources` entry that has NO sourcesContent. Without the
+    // `nullOnMissing` second arg, `SourceMapConsumer#sourceContentFor` would throw
+    // here and abort the entire flatten.
+    const gen = new SourceMapGenerator({ file: 'bundle.js' });
+    gen.addMapping({
+      generated: { line: 1, column: 0 },
+      original: { line: 1, column: 0 },
+      source: 'a.ts',
+    });
+    // Deliberately no `setSourceContent` call. SourceMapGenerator emits an empty
+    // `sourcesContent: []`, which the consumer treats as "missing for every source".
+    const map = JSON.parse(gen.toString()) as Record<string, unknown>;
+
+    await expect(flattenMapForHermes(map, 'X\nAAA', 1)).resolves.toBeDefined();
+  });
+
   test('clamps when a mapping references a generated line past the bundle length', async () => {
     // Map claims a mapping on generated line 5, but the bundle only has 3 lines.
     // The function should clamp to the last known line rather than throw / corrupt.

--- a/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
+++ b/packages/faro-metro-plugin/src/test/flattenMapForHermes.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect } from '@jest/globals';
+import { SourceMapConsumer, SourceMapGenerator, type RawSourceMap } from 'source-map';
+import { flattenMapForHermes } from '../flattenMapForHermes';
+
+/**
+ * Build a tiny multi-line source map describing `code` and return the JSON form.
+ * Each mapping list element is `[genLine, genCol, source, origLine, origCol, name?]`.
+ */
+function makeMap(
+  file: string,
+  mappings: Array<[number, number, string, number, number, string?]>,
+  sourcesContent?: Record<string, string>
+): Record<string, unknown> {
+  const gen = new SourceMapGenerator({ file });
+  for (const [gl, gc, src, ol, oc, name] of mappings) {
+    gen.addMapping({
+      generated: { line: gl, column: gc },
+      original: { line: ol, column: oc },
+      source: src,
+      name,
+    });
+  }
+  if (sourcesContent) {
+    for (const [src, content] of Object.entries(sourcesContent)) {
+      gen.setSourceContent(src, content);
+    }
+  }
+  return JSON.parse(gen.toString()) as Record<string, unknown>;
+}
+
+describe('flattenMapForHermes', () => {
+  test('moves every mapping to generated line 1 with absolute byte offsets', async () => {
+    // Original code (what the map describes):
+    //   line 1: "AAAA"   (bytes 0..3)
+    //   line 2: "BBBB"   (bytes 5..8 after the \n at byte 4)
+    //   line 3: "CCCCCC" (bytes 10..15)
+    const map = makeMap('bundle.js', [
+      [1, 0, 'foo.ts', 10, 1],
+      [2, 4, 'foo.ts', 20, 2],
+      [3, 6, 'bar.ts', 30, 3],
+    ]);
+
+    // Final bundle = "PREAMBLE\n" (9 bytes, \n at byte 8) + original code.
+    // Original code line L starts at bundle byte:
+    //   L=1 → 9, L=2 → 14, L=3 → 19
+    const bundleCode = 'PREAMBLE\nAAAA\nBBBB\nCCCCCC';
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    // Result mappings must live on one line only (no `;` separators).
+    expect(flat.mappings).not.toContain(';');
+
+    // Verify each lookup resolves to the original source position.
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 9 })).toMatchObject({
+      source: 'foo.ts',
+      line: 10,
+      column: 1,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 18 })).toMatchObject({
+      source: 'foo.ts',
+      line: 20,
+      column: 2,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 25 })).toMatchObject({
+      source: 'bar.ts',
+      line: 30,
+      column: 3,
+    });
+  });
+
+  test('honours custom preambleLines for multi-line preambles', async () => {
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 1, 0],
+      [2, 2, 'a.ts', 2, 0],
+    ]);
+
+    // Two-line preamble: bundle line 3 (byte 6) is where original code line 1 starts.
+    //   "AB\nCD\n" → preamble; \n at bytes 2 and 5; line 3 starts at byte 6
+    //   "EE\nFF"  → original; line 1 starts at 6, line 2 starts at 9
+    const bundleCode = 'AB\nCD\nEE\nFF';
+    const flat = (await flattenMapForHermes(map, bundleCode, 2)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 6 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+    expect(consumer.originalPositionFor({ line: 1, column: 11 })).toMatchObject({
+      source: 'a.ts',
+      line: 2,
+      column: 0,
+    });
+  });
+
+  test('preserves sourcesContent and file fields', async () => {
+    const map = makeMap(
+      'bundle.js',
+      [[1, 0, 'a.ts', 1, 0]],
+      { 'a.ts': 'export const x = 1;\n' }
+    );
+    const flat = (await flattenMapForHermes(map, '!\nAAAA', 1)) as unknown as RawSourceMap;
+
+    expect(flat.file).toBe('bundle.js');
+    expect(flat.sourcesContent).toEqual(['export const x = 1;\n']);
+  });
+
+  test('preserves mapping name field', async () => {
+    const map = makeMap('bundle.js', [
+      [1, 0, 'a.ts', 5, 4, 'myFn'],
+    ]);
+
+    const flat = (await flattenMapForHermes(map, 'X\nAAA', 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    expect(consumer.originalPositionFor({ line: 1, column: 2 })).toMatchObject({
+      source: 'a.ts',
+      line: 5,
+      column: 4,
+      name: 'myFn',
+    });
+  });
+
+  test('clamps when a mapping references a generated line past the bundle length', async () => {
+    // Map claims a mapping on generated line 5, but the bundle only has 3 lines.
+    // The function should clamp to the last known line rather than throw / corrupt.
+    const map = makeMap('bundle.js', [[5, 1, 'a.ts', 1, 0]]);
+    const bundleCode = 'X\nY\nZ'; // 3 lines, lineStart = [0, 2, 4]
+
+    const flat = (await flattenMapForHermes(map, bundleCode, 1)) as unknown as RawSourceMap;
+
+    const consumer = await new SourceMapConsumer(flat);
+    // Without throwing: clamped to the last line start (4) + col (1) = 5.
+    expect(consumer.originalPositionFor({ line: 1, column: 5 })).toMatchObject({
+      source: 'a.ts',
+      line: 1,
+      column: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Hermes reports every JS stack frame as `(line=1, column=<byte offset>)`, independent of newlines in the source. The existing `+1` line-shift in the Metro plugin produces a map that JSC can use but Hermes can't — a lookup at `(1, byteOffset)` lands on the empty leading lines and returns no source.
- New `flattenMapForHermes(mapJson, bundleCode, preambleLines)` rewrites every mapping onto generated line 1 with `column` set to the absolute byte offset in the final bundle. The receiver can then resolve Hermes coords directly.
- New `hermes` option on `FaroMetroPluginOptions` (default `true`) selects between the flat map and the existing line-shift; set `hermes: false` to opt out for JSC-only builds.
- Unit tests cover single-line collapse, custom `preambleLines`, `sourcesContent` / `file` / `name` preservation, and out-of-range clamping.

## Why this matters

Built against the `yduartep/add-rn-simbolification-hermes` branch and validated end-to-end on a local Faro stack:

1. Without this change, the Hermes column is a byte offset (e.g. `1137488`) and lookups against the shifted multi-line map return null → source map appears to be ignored.
2. With this change the receiver resolves frames such as `sendCrashReport` to their original `.ts` source locations without any further changes in the SDK or receiver.

Targets `yduartep/add-rn-simbolification-hermes` so it merges into that PR's branch — once both land together, the Metro plugin works correctly under Hermes (the default RN runtime in 0.70+).

_PR description authored by Claude on Domas's behalf._