### PR TITLE
fix(bundlers-shared): send X-Scope-OrgID for local source-map endpoints

### DIFF
--- a/packages/faro-bundlers-shared/src/index.ts
+++ b/packages/faro-bundlers-shared/src/index.ts
@@ -48,6 +48,42 @@ interface UploadCompressedSourceMapsOptions {
 }
 
 
+/**
+ * Detect a source map endpoint that points at a local/development receiver — i.e. one
+ * not fronted by the Grafana Cloud gateway. Used to opt into sending an explicit
+ * `X-Scope-OrgID` header alongside the bearer auth: production gateways derive the tenant
+ * from the bearer token and overwrite client-supplied tenant headers, but a local
+ * `kwl-endpoint` reads `X-Scope-OrgID` directly via `dskit/user` (it does not parse
+ * `Authorization: Bearer x:y`). Returns `false` for any unparseable or non-local URL,
+ * so production uploads stay byte-for-byte identical.
+ */
+export function isLocalEndpoint(endpoint: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(endpoint);
+  } catch {
+    return false;
+  }
+  // `URL.hostname` returns IPv6 addresses with surrounding brackets (`[::1]`); strip
+  // them so the comparison below works for both literal and bracketed forms.
+  const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    host === "localhost" ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "0.0.0.0"
+  ) {
+    return true;
+  }
+  // RFC 1918 private IPv4 ranges — covers Docker bridge networks and
+  // Android emulator host loopback (10.0.2.2). Anything outside these
+  // ranges is treated as production.
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  return false;
+}
+
 export const validateProxyUrl = (proxyUrl: string): void => {
   if (!proxyUrl || typeof proxyUrl !== 'string') {
     throw new Error('Proxy URL must be a non-empty string');
@@ -109,12 +145,16 @@ export const uploadSourceMap = async (
   }
 
   verbose && consoleInfoOrange(`Uploading ${filename} to ${sourcemapEndpoint}`);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "Authorization": `Bearer ${stackId}:${apiKey}`,
+  };
+  if (isLocalEndpoint(sourcemapEndpoint)) {
+    headers["X-Scope-OrgID"] = String(stackId);
+  }
   await fetch(sourcemapEndpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "Authorization": `Bearer ${stackId}:${apiKey}`,
-    },
+    headers,
     body: fs.readFileSync(filePath),
     dispatcher: proxy ? new ProxyAgent(proxy) : undefined,
   })
@@ -170,12 +210,16 @@ export const uploadCompressedSourceMaps = async (
         .map((file) => file.split("/").pop())
         .join(", ")} to ${sourcemapEndpoint}`
     );
+  const gzipHeaders: Record<string, string> = {
+    "Content-Type": "application/gzip",
+    "Authorization": `Bearer ${stackId}:${apiKey}`,
+  };
+  if (isLocalEndpoint(sourcemapEndpoint)) {
+    gzipHeaders["X-Scope-OrgID"] = String(stackId);
+  }
   await fetch(sourcemapEndpoint, {
     method: "POST",
-    headers: {
-      "Content-Type": "application/gzip",
-      "Authorization": `Bearer ${stackId}:${apiKey}`,
-    },
+    headers: gzipHeaders,
     body: fs.readFileSync(tarball),
     dispatcher: proxy ? new ProxyAgent(proxy) : undefined,
   })

--- a/packages/faro-bundlers-shared/src/test/index.test.ts
+++ b/packages/faro-bundlers-shared/src/test/index.test.ts
@@ -10,6 +10,7 @@ import {
   modifySourceMapFileProperty,
   ensureSourceMapFileProperty,
   ensureSourceMapFileProperties,
+  isLocalEndpoint,
 } from '../index';
 
 
@@ -357,5 +358,45 @@ describe('ensureSourceMapFileProperties', () => {
 
     const result = JSON.parse(fs.readFileSync(path.join(tempDir, 'map123.js.map'), 'utf8'));
     expect(result.file).toBe('map123.js');
+  });
+});
+
+describe('isLocalEndpoint', () => {
+  test('returns true for localhost variants', () => {
+    expect(isLocalEndpoint('http://localhost:8000/faro/api/v1')).toBe(true);
+    expect(isLocalEndpoint('http://LOCALHOST:8000')).toBe(true);
+    expect(isLocalEndpoint('http://127.0.0.1:8000/api')).toBe(true);
+    expect(isLocalEndpoint('http://[::1]:8000')).toBe(true);
+    expect(isLocalEndpoint('http://0.0.0.0:8000')).toBe(true);
+  });
+
+  test('returns true for RFC 1918 private IPv4 ranges', () => {
+    // Android emulator loopback to host
+    expect(isLocalEndpoint('http://10.0.2.2:8000/faro/api/v1')).toBe(true);
+    expect(isLocalEndpoint('http://10.255.255.255/api')).toBe(true);
+    // Docker bridge / common LAN
+    expect(isLocalEndpoint('http://172.17.0.1:8000')).toBe(true);
+    expect(isLocalEndpoint('http://172.31.255.1:8000')).toBe(true);
+    expect(isLocalEndpoint('http://192.168.1.10:8000')).toBe(true);
+  });
+
+  test('returns false for production Grafana Cloud endpoints', () => {
+    expect(isLocalEndpoint('https://faro-api-prod-us-east-0.grafana.net/faro/api/v1')).toBe(false);
+    expect(isLocalEndpoint('https://example.grafana.net/api')).toBe(false);
+    expect(isLocalEndpoint('https://my-stack.grafana.net')).toBe(false);
+  });
+
+  test('returns false for public IPv4 addresses that fall outside private ranges', () => {
+    // 172.15.x.x and 172.32.x.x are public — must NOT match the 172.16/12 block check.
+    expect(isLocalEndpoint('http://172.15.0.1:8000')).toBe(false);
+    expect(isLocalEndpoint('http://172.32.0.1:8000')).toBe(false);
+    // 11.x.x.x and 9.x.x.x are public.
+    expect(isLocalEndpoint('http://11.0.0.1:8000')).toBe(false);
+    expect(isLocalEndpoint('http://9.255.255.255:8000')).toBe(false);
+  });
+
+  test('returns false for unparseable input', () => {
+    expect(isLocalEndpoint('not a url')).toBe(false);
+    expect(isLocalEndpoint('')).toBe(false);
   });
 });


### PR DESCRIPTION
Yo,

Found when running against local dev env with no cortex-gw, `X-Scope-OrgID` header is needed to upload successfully (it's injected by cortex-gw in cloud env). 

Vibed a change to add this header when targeting "local" network address