### PR TITLE
security: bump axios, fast-uri, ip-address to fix CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
     "typescript": "5.9.3"
   },
   "resolutions": {
-    "minimatch": "^8.0.5"
+    "minimatch": "^8.0.5",
+    "axios": "1.15.2",
+    "fast-uri": "3.1.2"
+  },
+  "dependencies": {
+    "axios": "1.15.2",
+    "fast-uri": "3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,10 +32,5 @@
     "axios": "1.15.2",
     "fast-uri": "3.1.2",
     "ip-address": "10.2.0"
-  },
-  "dependencies": {
-    "axios": "1.15.2",
-    "fast-uri": "3.1.2",
-    "ip-address": "^10.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
   "resolutions": {
     "minimatch": "^8.0.5",
     "axios": "1.15.2",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "ip-address": "10.2.0"
   },
   "dependencies": {
     "axios": "1.15.2",
-    "fast-uri": "3.1.2"
+    "fast-uri": "3.1.2",
+    "ip-address": "^10.1.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4254,10 +4254,10 @@ inquirer@12.9.6:
     run-async "^4.0.5"
     rxjs "^7.8.2"
 
-ip-address@^10.0.1:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.1.0.tgz#d8dcffb34d0e02eb241427444a6e23f5b0595aa4"
-  integrity sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==
+ip-address@10.2.0, ip-address@^10.0.1, ip-address@^10.1.1:
+  version "10.2.0"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
+  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 is-arrayish@^0.2.1:
   version "0.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4254,7 +4254,7 @@ inquirer@12.9.6:
     run-async "^4.0.5"
     rxjs "^7.8.2"
 
-ip-address@10.2.0, ip-address@^10.0.1, ip-address@^10.1.1:
+ip-address@10.2.0, ip-address@^10.0.1:
   version "10.2.0"
   resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
   integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,10 +2801,10 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
-  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+axios@1.15.0, axios@1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.2.tgz#eb8fb6d30349abace6ade5b4cb4d9e8a0dc23e5b"
+  integrity sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
@@ -3741,10 +3741,10 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+fast-uri@3.1.2, fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fb-watchman@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
## Summary

- Bump `axios` 1.15.0 → 1.15.2 (CVE-2026-42043, CVE-2026-42264, CVE-2026-42044, CVE-2026-42038, CVE-2026-42039, CVE-2026-42033, CVE-2026-42035, CVE-2026-42041, CVE-2026-42042, CVE-2026-42036, CVE-2026-42034, CVE-2026-42037, CVE-2026-42040 — 3 critical / 4 high / 5 medium / 1 low).
- Bump `fast-uri` 3.1.0 → 3.1.2 (CVE-2026-6321, CVE-2026-6322 — 2 high).
- Bump `ip-address` 10.1.0 → 10.2.0 (CVE-2026-42338 — 1 medium). Also pinned via `resolutions` so the transitive `^10.0.1` range (socks → smart-buffer) resolves to the fix.

Each bump uses a `resolutions` entry because transitive dependency ranges remained below the fixed version in the lockfile. These pins should be removed once parent deps catch up — leaving them in place can mask future drift.

_PR description authored by Claude on Domas's behalf._