### PR TITLE
chore: migrate GitHub App auth to token broker

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,23 +16,11 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
 
     steps:
-      - id: get-secrets
-        name: get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@0a7a2fc07560de0f2fe500ed9fd1f53ec7d86d33
-        with:
-          repo_secrets: |
-            FARO_SMU_CI_APP_ID=github:app-id
-            FARO_SMU_CI_PRIVATE_KEY=github:private-key
-
-      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        name: get github app token
+      - name: Mint GitHub App token
         id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ env.FARO_SMU_CI_APP_ID }}
-          private-key: ${{ env.FARO_SMU_CI_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: |
-            faro-javascript-bundler-plugins
+          github_app: app-o11y-kwl-ci
 
       - uses: googleapis/release-please-action@64d83e95d898ede84e4555719aba555c3244d469
         id: release

--- a/.github/workflows/renovate-reviewer.yml
+++ b/.github/workflows/renovate-reviewer.yml
@@ -16,21 +16,11 @@ jobs:
       PR_URL: ${{github.event.pull_request.html_url}}
       COMMITS_URL: ${{ github.event.pull_request.commits_url }}
     steps:
-      - name: Get secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@0a7a2fc07560de0f2fe500ed9fd1f53ec7d86d33
-        with:
-          repo_secrets: |
-            FARO_SMU_CI_APP_ID=github:app-id
-            FARO_SMU_CI_PRIVATE_KEY=github:private-key
-
-      - name: Create GitHub app token
+      - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          app-id: ${{ env.FARO_SMU_CI_APP_ID }}
-          private-key: ${{ env.FARO_SMU_CI_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
+          github_app: app-o11y-kwl-ci
 
       - name: Approve security updates
         if: contains(github.event.pull_request.labels.*.name, 'automerge-security-update')


### PR DESCRIPTION
Incident comms ask us to move off direct Vault access for GitHub App private keys. Migrates the two workflows that mint `app-o11y-kwl-ci` tokens to the [token broker](https://github.com/grafana/shared-workflows/tree/main/actions/create-github-app-token); each workflow's `get-vault-secrets` step is dropped since it only fetched the App creds.

Blocked on broker config in grafana/deployment_tools#590394 — must merge and Atlantis-apply first.

_PR description authored by Claude on Domas's behalf._