### PR TITLE
ci(release-please): refresh yarn.lock on release PR branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -39,6 +39,60 @@ jobs:
           echo "$NEEDS_CONTEXT"
           echo "$STEPS_CONTEXT"
 
+      # release-please rewrites cross-package dep ranges in each package.json
+      # (e.g. `@grafana/faro-bundlers-shared` from `^0.10.1` to `^0.11.0`) but
+      # does not touch yarn.lock. The Pull Request workflow runs
+      # `yarn install --immutable`, which fails on the release PR because the
+      # resolution would change — additionally, Yarn berry auto-enables
+      # hardened mode on public PR workflows, which forbids any lockfile
+      # mutation. Refresh yarn.lock on the release branch so CI passes.
+      - name: Resolve release PR branch
+        id: release-branch
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          BRANCH="$(echo "$PR_JSON" | jq -r '.headBranchName')"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release PR branch
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+        with:
+          ref: ${{ steps.release-branch.outputs.branch }}
+          token: ${{ steps.get-github-app-token.outputs.token }}
+          persist-credentials: true
+
+      - name: Enable corepack
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        run: corepack enable
+
+      - name: Setup Node.js
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version: lts/*
+
+      - name: Refresh yarn.lock on release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        run: |
+          set -euo pipefail
+          # `--mode update-lockfile` writes the lockfile without installing
+          # node_modules and bypasses Yarn berry's hardened-mode lockfile
+          # mutation check, which is what we hit on the release PR.
+          yarn install --mode update-lockfile
+          if git diff --quiet -- yarn.lock; then
+            echo "yarn.lock already in sync."
+            exit 0
+          fi
+          # Match the identity the release-please-action uses for its commits
+          # on the same branch, so this commit appears as the same bot.
+          git config user.name 'app-o11y-kwl-ci[bot]'
+          git config user.email 'app-o11y-kwl-ci[bot]@users.noreply.github.com'
+          git add yarn.lock
+          git commit -m 'chore: refresh yarn.lock for release PR'
+          git push
+
   publish:
     name: Publish to NPM
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

The current release PR (#557) is failing CI on `yarn install --immutable` with `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden`.

What's happening:

1. release-please opens the release PR and bumps cross-package dep ranges in each `package.json` — e.g. `@grafana/faro-bundlers-shared` from `^0.10.1` → `^0.11.0`.
2. release-please **does not touch `yarn.lock`**. The lockfile still resolves the old `^0.10.x` ranges.
3. `run-tests.yml` runs `yarn install --immutable` on the PR.
4. Yarn berry 4.14.1 also auto-enables **hardened mode** on workflows triggered by public PRs. Hardened mode forbids any lockfile mutation regardless of `--immutable`.
5. The new ranges would require lockfile changes → CI fails.

This will recur on every release PR until fixed in the workflow.

## What

After release-please opens or updates a release PR, the workflow now:

1. Resolves the release PR's branch name from `steps.release.outputs.pr`.
2. Checks out that branch (using the same GitHub App token release-please uses, so the push is allowed by main-branch / app-only rulesets).
3. Runs `yarn install --mode update-lockfile`. This writes the lockfile without installing `node_modules` and bypasses Yarn berry's hardened-mode lockfile mutation check (which would otherwise also block this step).
4. If anything changed, commits as the `app-o11y-kwl-ci[bot]` identity (matching release-please's commit identity on the same branch) and pushes back to the release PR branch. The push triggers a re-run of `run-tests`, which now passes.

If no lockfile changes are needed, the step is a no-op.

This is the same pattern faro-web-sdk uses for the same reason (see `.github/workflows/release-please.yml` in that repo).

## Effect on the current broken release PR #557

This change will not retroactively fix #557 — it has to merge to main first, then release-please needs to push an update to #557 (a new commit, or close+regenerate). Easiest unblock after merge: close #557 and let release-please open a fresh one on its next run.

## Links

- Failing CI: https://github.com/grafana/faro-javascript-bundler-plugins/actions/runs/26245080796/job/77241205544
- faro-web-sdk equivalent: https://github.com/grafana/faro-web-sdk/blob/main/.github/workflows/release-please.yml (Refresh yarn.lock step)

## Checklist

- [ ] Tests added — n/a, CI-only change
- [ ] Changelog updated — n/a, CI/infra
- [ ] Documentation updated — n/a