### PR TITLE
chore(ci): add CODEOWNERS, drop dead NPM_TOKEN fetch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -49,13 +49,6 @@ jobs:
       id-token: write
     if: ${{ needs.release-please.outputs.releases_created }}
     steps:
-      - id: get-secrets
-        name: get secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@0a7a2fc07560de0f2fe500ed9fd1f53ec7d86d33
-        with:
-          repo_secrets: |
-            NPM_TOKEN=npm:token
-
       - name: Checkout
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @grafana/frontend-o11y


### PR DESCRIPTION
## Summary

- **CODEOWNERS** — `@grafana/frontend-o11y` as default reviewer. Guards changes to `release-please.yml` against landing without an owner's eyes, given that workflow runs the npm Trusted Publishing OIDC step. Needs `require_code_owner_review: true` on the `main` ruleset to actually block merges — followup in repo settings / Terraform.
- **Drop Vault `NPM_TOKEN` fetch in publish job** — dead since 28bbb87 ("fix: enable trusted publishing") removed the matching `npm config set _authToken` step and `NODE_AUTH_TOKEN` env. The secret was fetched and never consumed. Trusted Publishing is confirmed active end-to-end on `@grafana/faro-webpack-plugin@0.11.1` (Sigstore cert OID `1.3.6.1.4.1.57264.1.23` = `npm-trusted-publishing`).

_PR description authored by Claude on Domas's behalf._