### PR TITLE
ci: add CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,70 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+  pull_request:
+  schedule:
+    - cron: '0 6 * * MON'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  analysis:
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ['actions', 'javascript-typescript']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          filter: 'tree:0'
+          persist-credentials: false
+          show-progress: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          build-mode: none
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
+        with:
+          category: '/language:${{ matrix.language }}'
+
+  codeql:
+    if: ${{ !cancelled() }}
+    needs: [analysis]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Report status
+        shell: bash
+        env:
+          SCAN_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+        run: |
+          if [ "${SCAN_SUCCESS}" == "true" ]
+          then
+            echo 'CodeQL analysis successful'
+          else
+            echo 'CodeQL analysis failed'
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a CodeQL scanning workflow, mirroring [grafana/faro-web-sdk#2095](https://github.com/grafana/faro-web-sdk/pull/2095):

- Scans `javascript-typescript` (source) and `actions` (workflow YAML, for injection patterns).
- `security-and-quality` query suite.
- Runs on push to `main`, on PRs, weekly Monday 06:00 UTC, and on manual dispatch.
- Empty top-level `permissions: {}` with per-job grants.
- All actions pinned to commit SHAs.
- Aggregation `codeql` job for a single stable status check name.

Resolves #561.

CodeQL default setup may currently be enabled in repo Settings → Code security → Code scanning. Default setup and an advanced (workflow file) setup can't run side-by-side without duplicate results — default setup needs to be turned off in the same window as merging this PR.

## Test plan

- [ ] `analysis (javascript-typescript)` and `analysis (actions)` jobs pass on this PR.
- [ ] `codeql` aggregation job reports green.
- [ ] Default-setup CodeQL disabled in Settings before merge.
- [ ] After merge: results visible under Security → Code scanning.