### PR TITLE
chore: stricter renovate rules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,8 @@
   "separateMultipleMajor": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "Group npm dependencies",


### PR DESCRIPTION
# What

Add "internalChecksFilter": "strict" to [.github/renovate.json](https://github.com/grafana/faro-javascript-bundler-plugins/pull/.github/renovate.json) so Renovate withholds a PR until the release clears the 7-day age gate, matching Yarn-side enforcement.

If the self-hosted bot forces a non-strict value globally, this repo-level setting is ignored and the change must move to the bot config — we'll know from whether the too-new PRs stop appearing.