### PR TITLE
chore: adding mobile o11y codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @grafana/frontend-o11y
+* @grafana/frontend-o11y @grafana/mobile-o11y-engineers


### PR DESCRIPTION
# why 

mobile o11y owns part of this repo now, they should have codeowner privileges
