### PR TITLE
feat: implement faro-cli android upload and Gradle-derived bundle id for Metro

### DIFF
--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -61,6 +61,29 @@ const firstNonEmpty = (...values: Array<string | undefined>): string => {
   return '';
 };
 
+function redactCredential(value: string): string {
+  if (value.length <= 8) {
+    return '****';
+  }
+  return value.substring(0, 4) + '****';
+}
+
+function redactBearerToken(stackId: string, apiKey: string): string {
+  return `Bearer ${redactCredential(stackId)}:${redactCredential(apiKey)}`;
+}
+
+function buildVerboseCurlCommand(command: string, config: ResolvedConfig): string {
+  let redacted = command;
+  redacted = redacted.replace(
+    new RegExp(`Bearer ${config.stackId}:${config.apiKey}`, 'g'),
+    redactBearerToken(config.stackId, config.apiKey)
+  );
+  if (command.includes('--proxy-user')) {
+    redacted = redacted.replace(/--proxy-user "([^"]+)"/g, '--proxy-user "****"');
+  }
+  return redacted;
+}
+
 interface ResolvedConfig {
   endpoint: string;
   appId: string;
@@ -77,6 +100,15 @@ function formatAndroidSymbolsBundleId(
   versionCode: string,
   versionName: string
 ): string {
+  if (applicationId.includes('@')) {
+    throw new Error(`applicationId cannot contain '@': ${applicationId}`);
+  }
+  if (versionName.includes('@')) {
+    throw new Error(`versionName cannot contain '@': ${versionName}`);
+  }
+  if (!/^\d+$/.test(versionCode)) {
+    throw new Error(`versionCode must be an integer: ${versionCode}`);
+  }
   return `${applicationId}@${versionCode}@${versionName}`;
 }
 
@@ -128,6 +160,14 @@ function resolveConfig(opts: AndroidSymbolsUploadOptions): ResolveResult {
     return { exitCode: 2, reason: `native-symbols file not found: ${resolvedNative}` };
   }
 
+  let bundleId: string;
+  try {
+    bundleId = formatAndroidSymbolsBundleId(applicationId, versionCode, versionName);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { exitCode: 2, reason: message };
+  }
+
   return {
     exitCode: 0,
     config: {
@@ -135,7 +175,7 @@ function resolveConfig(opts: AndroidSymbolsUploadOptions): ResolveResult {
       appId,
       stackId,
       apiKey,
-      bundleId: formatAndroidSymbolsBundleId(applicationId, versionCode, versionName),
+      bundleId,
       mappingPath: resolvedMapping,
       nativeSymbolsPath: resolvedNative,
     },
@@ -158,6 +198,12 @@ export function buildAndroidSymbolsUploadRequests(
   abiArtifacts: AbiZipArtifact[] = []
 ): AndroidSymbolsUploadRequest[] {
   const normalizedEndpoint = config.endpoint.replace(/\/$/, '');
+  
+  // Validate URL to prevent command injection
+  if (normalizedEndpoint.includes('"') || normalizedEndpoint.includes('`') || normalizedEndpoint.includes('$')) {
+    throw new Error('Invalid endpoint URL: contains shell metacharacters');
+  }
+  
   const url = `${normalizedEndpoint}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
 
   const headers: Record<string, string> = {
@@ -199,6 +245,15 @@ export function buildAndroidSymbolsUploadRequests(
   return requests;
 }
 
+/**
+ * Executes curl command and parses HTTP status from output.
+ * 
+ * Security note: execSync with shell=true is used here because:
+ * 1. All inputs (URLs, file paths) are validated before reaching this function
+ * 2. File paths are resolved and checked for existence before use
+ * 3. Credentials and proxy settings are properly quoted
+ * 4. The command structure is deterministic and not derived from untrusted input
+ */
 function runCurl(command: string): { statusCode: number; body: string } {
   const result = execSync(command, { encoding: 'utf8' });
   const lines = result.trim().split('\n');
@@ -234,7 +289,10 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
       process.stdout.write(
         `[dry-run] would upload ${req.label} (${req.localBytes} bytes) for ${config.bundleId} to ${targetUrl}\n`
       );
-      opts.verbose && process.stdout.write(`[dry-run] ${req.curlCommand}\n`);
+      if (opts.verbose) {
+        const redacted = buildVerboseCurlCommand(req.curlCommand, config);
+        process.stdout.write(`[dry-run] ${redacted}\n`);
+      }
     }
     return 0;
   }

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -277,9 +277,16 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
 
   let abiArtifacts: AbiZipArtifact[] = [];
   let tempDir: string | undefined;
-  if (config.nativeSymbolsPath) {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-abi-'));
-    abiArtifacts = packNativeSymbolsByAbi(config.nativeSymbolsPath, tempDir);
+  try {
+    if (config.nativeSymbolsPath) {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-abi-'));
+      abiArtifacts = packNativeSymbolsByAbi(config.nativeSymbolsPath, tempDir);
+    }
+  } catch (err) {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+    throw err;
   }
 
   const requests = buildAndroidSymbolsUploadRequests(config, opts, abiArtifacts);

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -253,15 +253,56 @@ export function buildAndroidSymbolsUploadRequests(
 
 /**
  * Executes curl command and parses HTTP status from output.
- * 
- * Security note: execSync with shell=true is used here because:
- * 1. All inputs (URLs, file paths) are validated before reaching this function
- * 2. File paths are resolved and checked for existence before use
- * 3. Credentials and proxy settings are properly quoted
- * 4. The command structure is deterministic and not derived from untrusted input
+ * Uses execFileSync to avoid shell interpretation and prevent command injection.
  */
 function runCurl(command: string): { statusCode: number; body: string } {
-  const result = execSync(command, { encoding: 'utf8' });
+  // Parse curl command string into arguments array for execFileSync
+  // The command format is: curl -s -w "\n%{http_code}" ... [args]
+  const args: string[] = [];
+  
+  // Extract arguments from command string (skip 'curl' prefix if present)
+  const cmdString = command.startsWith('curl ') ? command.substring(5) : command;
+  
+  // Simple argument parser that handles quoted strings
+  let current = '';
+  let inQuote = false;
+  let escapeNext = false;
+  
+  for (let i = 0; i < cmdString.length; i++) {
+    const char = cmdString[i];
+    
+    if (escapeNext) {
+      current += char;
+      escapeNext = false;
+      continue;
+    }
+    
+    if (char === '\\') {
+      escapeNext = true;
+      continue;
+    }
+    
+    if (char === '"') {
+      inQuote = !inQuote;
+      continue;
+    }
+    
+    if (char === ' ' && !inQuote) {
+      if (current) {
+        args.push(current);
+        current = '';
+      }
+      continue;
+    }
+    
+    current += char;
+  }
+  
+  if (current) {
+    args.push(current);
+  }
+  
+  const result = execFileSync('curl', args, { encoding: 'utf8' });
   const lines = result.trim().split('\n');
   const statusCode = Number.parseInt(lines[lines.length - 1] ?? '', 10);
   const body = lines.slice(0, -1).join('\n').trim();

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -215,6 +215,8 @@ export function buildAndroidSymbolsUploadRequests(
     .map(([key, value]) => `-H "${key}: ${value}"`)
     .join(' ');
 
+  if (opts.proxy && /["`$]/.test(opts.proxy)) throw new Error('Invalid proxy URL: contains shell metacharacters');
+  if (opts.proxyUser && /["`$]/.test(opts.proxyUser)) throw new Error('Invalid proxy credentials: contains shell metacharacters');
   const proxyArg = opts.proxy ? `--proxy "${opts.proxy}"` : '';
   const proxyUserArg = opts.proxyUser ? `--proxy-user "${opts.proxyUser}"` : '';
   const baseCurl = `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg}`.replace(/\s+/g, ' ').trim();

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -228,7 +228,7 @@ export function buildAndroidSymbolsUploadRequests(
     requests.push({
       label: 'mapping',
       localBytes: mappingBytes,
-      curlCommand: `${baseCurl} "${url}" ${headerArgs} -F "mapping=@${config.mappingPath};type=text/plain"`,
+      curlCommand: `${baseCurl} "${url}" ${headerArgs} -F "mapping=@\\"${config.mappingPath}\\";type=text/plain"`,
     });
   }
 
@@ -238,7 +238,7 @@ export function buildAndroidSymbolsUploadRequests(
       localBytes: artifact.bytes,
       curlCommand:
         `${baseCurl} "${url}" ${headerArgs} -F "abi=${artifact.abi}" ` +
-        `-F "native-symbols=@${artifact.zipPath};type=application/zip"`,
+        `-F "native-symbols=@\\"${artifact.zipPath}\\";type=application/zip"`,
     });
   }
 

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -1,8 +1,11 @@
 import { execSync } from 'child_process';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 import { consoleInfoOrange, isLocalEndpoint } from '@grafana/faro-bundlers-shared';
+
+import { AbiZipArtifact, packNativeSymbolsByAbi } from './nativeSymbolsByAbi';
 
 /**
  * Options for `faro-cli android upload`.
@@ -23,7 +26,9 @@ import { consoleInfoOrange, isLocalEndpoint } from '@grafana/faro-bundlers-share
  *   - --version-name   / FARO_ANDROID_VERSION_NAME
  *
  * At least one of `--mapping` (R8/ProGuard mapping.txt) or `--native-symbols`
- * (native-debug-symbols.zip) must be provided.
+ * (native-debug-symbols.zip) must be provided. When native symbols are provided,
+ * the CLI splits the AGP zip by ABI and uploads one POST per ABI (each under the
+ * HTTP body size limit).
  */
 export interface AndroidSymbolsUploadOptions {
   endpoint?: string;
@@ -67,7 +72,7 @@ interface ResolvedConfig {
 }
 
 /** Encoded Android symbols bundle id: `{applicationId}@{versionCode}@{versionName}`. */
-export function formatAndroidSymbolsBundleId(
+function formatAndroidSymbolsBundleId(
   applicationId: string,
   versionCode: string,
   versionName: string
@@ -137,19 +142,27 @@ function resolveConfig(opts: AndroidSymbolsUploadOptions): ResolveResult {
   };
 }
 
+export interface AndroidSymbolsUploadRequest {
+  label: string;
+  curlCommand: string;
+  localBytes: number;
+}
+
 /**
- * Builds the multipart `curl` command used to POST Android symbol artifacts.
- * Exported for testing. `curl -F` sets `Content-Type: multipart/form-data`
- * automatically, so no explicit content-type header is added.
+ * Builds curl commands for mapping (optional) and each ABI zip (when native symbols provided).
+ * Exported for testing.
  */
-export function buildAndroidSymbolsCurlCommand(config: ResolvedConfig, opts: AndroidSymbolsUploadOptions): string {
+export function buildAndroidSymbolsUploadRequests(
+  config: ResolvedConfig,
+  opts: AndroidSymbolsUploadOptions,
+  abiArtifacts: AbiZipArtifact[] = []
+): AndroidSymbolsUploadRequest[] {
   const normalizedEndpoint = config.endpoint.replace(/\/$/, '');
   const url = `${normalizedEndpoint}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${config.stackId}:${config.apiKey}`,
   };
-  // Local dev (noop auth) derives the stack from X-Scope-OrgID instead of the token.
   if (isLocalEndpoint(url)) {
     headers['X-Scope-OrgID'] = config.stackId;
   }
@@ -158,31 +171,44 @@ export function buildAndroidSymbolsCurlCommand(config: ResolvedConfig, opts: And
     .map(([key, value]) => `-H "${key}: ${value}"`)
     .join(' ');
 
-  const formArgs: string[] = [];
-  if (config.mappingPath) {
-    formArgs.push(`-F "mapping=@${config.mappingPath};type=text/plain"`);
-  }
-  if (config.nativeSymbolsPath) {
-    formArgs.push(`-F "native-symbols=@${config.nativeSymbolsPath};type=application/zip"`);
-  }
-
   const proxyArg = opts.proxy ? `--proxy "${opts.proxy}"` : '';
   const proxyUserArg = opts.proxyUser ? `--proxy-user "${opts.proxyUser}"` : '';
+  const baseCurl = `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg}`.replace(/\s+/g, ' ').trim();
 
-  // -w prints the HTTP status code on its own trailing line so we can detect failures.
-  return `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} ${formArgs.join(' ')}`
-    .replace(/\s+/g, ' ')
-    .trim();
+  const requests: AndroidSymbolsUploadRequest[] = [];
+
+  if (config.mappingPath) {
+    const mappingBytes = fs.statSync(config.mappingPath).size;
+    requests.push({
+      label: 'mapping',
+      localBytes: mappingBytes,
+      curlCommand: `${baseCurl} "${url}" ${headerArgs} -F "mapping=@${config.mappingPath};type=text/plain"`,
+    });
+  }
+
+  for (const artifact of abiArtifacts) {
+    requests.push({
+      label: `native-symbols (${artifact.abi})`,
+      localBytes: artifact.bytes,
+      curlCommand:
+        `${baseCurl} "${url}" ${headerArgs} -F "abi=${artifact.abi}" ` +
+        `-F "native-symbols=@${artifact.zipPath};type=application/zip"`,
+    });
+  }
+
+  return requests;
+}
+
+function runCurl(command: string): { statusCode: number; body: string } {
+  const result = execSync(command, { encoding: 'utf8' });
+  const lines = result.trim().split('\n');
+  const statusCode = Number.parseInt(lines[lines.length - 1] ?? '', 10);
+  const body = lines.slice(0, -1).join('\n').trim();
+  return { statusCode, body };
 }
 
 /**
- * Resolves config, then uploads the Android symbol artifacts via `curl`.
- *
- * Returns a numeric exit code (so it is easy to test and the commander action
- * can `process.exit` on non-zero):
- *   - 0 success
- *   - 1 upload failure (non-2xx response or curl error)
- *   - 2 fatal config/validation error
+ * Resolves config, splits native symbols by ABI, then uploads via sequential curl POSTs.
  */
 export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions): Promise<number> => {
   const resolved = resolveConfig(opts);
@@ -192,47 +218,52 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
   }
 
   const config = resolved.config;
-  const command = buildAndroidSymbolsCurlCommand(config, opts);
   const targetUrl = `${config.endpoint.replace(/\/$/, '')}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
 
-  const artifactList = [
-    config.mappingPath ? `mapping=${path.basename(config.mappingPath)}` : null,
-    config.nativeSymbolsPath ? `native-symbols=${path.basename(config.nativeSymbolsPath)}` : null,
-  ]
-    .filter(Boolean)
-    .join(', ');
+  let abiArtifacts: AbiZipArtifact[] = [];
+  let tempDir: string | undefined;
+  if (config.nativeSymbolsPath) {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-abi-'));
+    abiArtifacts = packNativeSymbolsByAbi(config.nativeSymbolsPath, tempDir);
+  }
+
+  const requests = buildAndroidSymbolsUploadRequests(config, opts, abiArtifacts);
 
   if (opts.dryRun) {
-    process.stdout.write(
-      `[dry-run] would upload Android symbols (${artifactList}) for ${config.bundleId} to ${targetUrl}\n`
-    );
-    opts.verbose && process.stdout.write(`[dry-run] ${command}\n`);
+    for (const req of requests) {
+      process.stdout.write(
+        `[dry-run] would upload ${req.label} (${req.localBytes} bytes) for ${config.bundleId} to ${targetUrl}\n`
+      );
+      opts.verbose && process.stdout.write(`[dry-run] ${req.curlCommand}\n`);
+    }
     return 0;
   }
 
   opts.verbose &&
-    consoleInfoOrange(
-      `Uploading Android symbols (${artifactList}) for ${config.bundleId} to ${targetUrl}`
-    );
+    consoleInfoOrange(`Uploading Android symbols (${requests.length} POSTs) for ${config.bundleId} to ${targetUrl}`);
 
   try {
-    const result = execSync(command, { encoding: 'utf8' });
-    const lines = result.trim().split('\n');
-    const statusCode = Number.parseInt(lines[lines.length - 1] ?? '', 10);
-    const body = lines.slice(0, -1).join('\n').trim();
-
-    if (Number.isNaN(statusCode) || statusCode < 200 || statusCode >= 300) {
-      process.stderr.write(`Android symbols upload failed (HTTP ${lines[lines.length - 1] ?? '?'}).\n`);
-      if (body) {
-        process.stderr.write(`${body}\n`);
+    for (const req of requests) {
+      opts.verbose && process.stdout.write(`[Faro] uploading ${req.label} (${req.localBytes} bytes)\n`);
+      const { statusCode, body } = runCurl(req.curlCommand);
+      if (Number.isNaN(statusCode) || statusCode < 200 || statusCode >= 300) {
+        process.stderr.write(`Android symbols upload failed for ${req.label} (HTTP ${statusCode}).\n`);
+        if (body) {
+          process.stderr.write(`${body}\n`);
+        }
+        return 1;
       }
-      return 1;
+      process.stdout.write(`Uploaded ${req.label} (${req.localBytes} bytes, HTTP ${statusCode}).\n`);
     }
 
-    process.stdout.write(`Upload complete (HTTP ${statusCode}).\n`);
+    process.stdout.write(`Upload complete (${requests.length} POSTs).\n`);
     return 0;
   } catch (error) {
     process.stderr.write(`Error executing curl command: ${error instanceof Error ? error.message : String(error)}\n`);
     return 1;
+  } finally {
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
   }
 };

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -277,8 +277,19 @@ function runCurl(command: string): { statusCode: number; body: string } {
       continue;
     }
     
+    // Only treat backslash as escape for sequences the command builder emits (e.g., \" for literal quotes)
+    // Otherwise preserve backslashes verbatim to support:
+    // - curl's -w "\\n%{http_code}" format
+    // - Windows file paths like C:\\Users\\...
     if (char === '\\') {
-      escapeNext = true;
+      const nextChar = cmdString[i + 1];
+      if (nextChar === '"') {
+        // Escape sequence for literal quote - consume backslash and set escape flag
+        escapeNext = true;
+        continue;
+      }
+      // Not an escape sequence we emit - preserve the backslash
+      current += char;
       continue;
     }
     

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -215,8 +215,14 @@ export function buildAndroidSymbolsUploadRequests(
     .map(([key, value]) => `-H "${key}: ${value}"`)
     .join(' ');
 
-  if (opts.proxy && /["`$]/.test(opts.proxy)) throw new Error('Invalid proxy URL: contains shell metacharacters');
-  if (opts.proxyUser && /["`$]/.test(opts.proxyUser)) throw new Error('Invalid proxy credentials: contains shell metacharacters');
+  // Validate proxy and credentials don't contain shell metacharacters (use safer string methods instead of regex to avoid ReDoS)
+  const shellMetachars = ['"', '`', '$'];
+  if (opts.proxy && shellMetachars.some(char => opts.proxy!.includes(char))) {
+    throw new Error('Invalid proxy URL: contains shell metacharacters');
+  }
+  if (opts.proxyUser && shellMetachars.some(char => opts.proxyUser!.includes(char))) {
+    throw new Error('Invalid proxy credentials: contains shell metacharacters');
+  }
   const proxyArg = opts.proxy ? `--proxy "${opts.proxy}"` : '';
   const proxyUserArg = opts.proxyUser ? `--proxy-user "${opts.proxyUser}"` : '';
   const baseCurl = `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg}`.replace(/\s+/g, ' ').trim();

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -74,10 +74,8 @@ function redactBearerToken(stackId: string, apiKey: string): string {
 
 function buildVerboseCurlCommand(command: string, config: ResolvedConfig): string {
   let redacted = command;
-  redacted = redacted.replace(
-    new RegExp(`Bearer ${config.stackId}:${config.apiKey}`, 'g'),
-    redactBearerToken(config.stackId, config.apiKey)
-  );
+  const rawBearerToken = `Bearer ${config.stackId}:${config.apiKey}`;
+  redacted = redacted.split(rawBearerToken).join(redactBearerToken(config.stackId, config.apiKey));
   if (command.includes('--proxy-user')) {
     redacted = redacted.replace(/--proxy-user "([^"]+)"/g, '--proxy-user "****"');
   }

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -202,7 +202,7 @@ export function buildAndroidSymbolsUploadRequests(
     throw new Error('Invalid endpoint URL: contains shell metacharacters');
   }
   
-  const url = `${normalizedEndpoint}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
+  const url = `${normalizedEndpoint}/app/${encodeURIComponent(config.appId)}/symbols/android/${encodeURIComponent(config.bundleId)}`;
 
   const headers: Record<string, string> = {
     Authorization: `Bearer ${config.stackId}:${config.apiKey}`,

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -1,0 +1,238 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+import { consoleInfoOrange, isLocalEndpoint } from '@grafana/faro-bundlers-shared';
+
+/**
+ * Options for `faro-cli android upload`.
+ *
+ * Connection settings (endpoint, appId, stackId, apiKey) can each come from a
+ * CLI flag or the matching env var (first non-empty wins: flag > env):
+ *
+ *   - --endpoint   / FARO_SOURCEMAP_ENDPOINT
+ *   - --app-id     / FARO_SOURCEMAP_APP_ID
+ *   - --stack-id   / FARO_SOURCEMAP_STACK_ID
+ *   - --api-key    / FARO_SOURCEMAP_API_KEY
+ *
+ * Build identity (the lookup key the collector uses to retrace crashes) can
+ * likewise come from a flag or env:
+ *
+ *   - --application-id / FARO_ANDROID_APPLICATION_ID
+ *   - --version-code   / FARO_ANDROID_VERSION_CODE
+ *   - --version-name   / FARO_ANDROID_VERSION_NAME
+ *
+ * At least one of `--mapping` (R8/ProGuard mapping.txt) or `--native-symbols`
+ * (native-debug-symbols.zip) must be provided.
+ */
+export interface AndroidSymbolsUploadOptions {
+  endpoint?: string;
+  appId?: string;
+  stackId?: string;
+  apiKey?: string;
+  applicationId?: string;
+  versionCode?: string;
+  versionName?: string;
+  /** Path to the R8/ProGuard mapping.txt. */
+  mapping?: string;
+  /** Path to the native-debug-symbols.zip. */
+  nativeSymbols?: string;
+  verbose: boolean;
+  dryRun: boolean;
+  proxy?: string;
+  proxyUser?: string;
+}
+
+const trimmedString = (value: unknown): string | undefined =>
+  typeof value === 'string' && value.trim() !== '' ? value.trim() : undefined;
+
+const firstNonEmpty = (...values: Array<string | undefined>): string => {
+  for (const value of values) {
+    const trimmed = trimmedString(value);
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return '';
+};
+
+interface ResolvedConfig {
+  endpoint: string;
+  appId: string;
+  stackId: string;
+  apiKey: string;
+  bundleId: string;
+  mappingPath?: string;
+  nativeSymbolsPath?: string;
+}
+
+/** Encoded Android symbols bundle id: `{applicationId}@{versionCode}@{versionName}`. */
+export function formatAndroidSymbolsBundleId(
+  applicationId: string,
+  versionCode: string,
+  versionName: string
+): string {
+  return `${applicationId}@${versionCode}@${versionName}`;
+}
+
+interface ResolveResult {
+  config?: ResolvedConfig;
+  /** 0 ok, 2 fatal config/validation. */
+  exitCode: 0 | 2;
+  reason?: string;
+}
+
+function resolveConfig(opts: AndroidSymbolsUploadOptions): ResolveResult {
+  const endpoint = firstNonEmpty(opts.endpoint, process.env.FARO_SOURCEMAP_ENDPOINT);
+  const appId = firstNonEmpty(opts.appId, process.env.FARO_SOURCEMAP_APP_ID);
+  const stackId = firstNonEmpty(opts.stackId, process.env.FARO_SOURCEMAP_STACK_ID);
+  const apiKey = firstNonEmpty(opts.apiKey, process.env.FARO_SOURCEMAP_API_KEY);
+  const applicationId = firstNonEmpty(opts.applicationId, process.env.FARO_ANDROID_APPLICATION_ID);
+  const versionCode = firstNonEmpty(opts.versionCode, process.env.FARO_ANDROID_VERSION_CODE);
+  const versionName = firstNonEmpty(opts.versionName, process.env.FARO_ANDROID_VERSION_NAME);
+
+  const missing: string[] = [];
+  if (!endpoint) missing.push('endpoint (--endpoint or FARO_SOURCEMAP_ENDPOINT)');
+  if (!appId) missing.push('appId (--app-id or FARO_SOURCEMAP_APP_ID)');
+  if (!stackId) missing.push('stackId (--stack-id or FARO_SOURCEMAP_STACK_ID)');
+  if (!apiKey) missing.push('apiKey (--api-key or FARO_SOURCEMAP_API_KEY)');
+  if (!applicationId) missing.push('applicationId (--application-id or FARO_ANDROID_APPLICATION_ID)');
+  if (!versionCode) missing.push('versionCode (--version-code or FARO_ANDROID_VERSION_CODE)');
+  if (!versionName) missing.push('versionName (--version-name or FARO_ANDROID_VERSION_NAME)');
+
+  if (missing.length > 0) {
+    return { exitCode: 2, reason: `Missing required settings:\n  - ${missing.join('\n  - ')}` };
+  }
+
+  const mappingPath = trimmedString(opts.mapping);
+  const nativeSymbolsPath = trimmedString(opts.nativeSymbols);
+  if (!mappingPath && !nativeSymbolsPath) {
+    return {
+      exitCode: 2,
+      reason: 'Provide at least one of --mapping <mapping.txt> or --native-symbols <native-debug-symbols.zip>.',
+    };
+  }
+
+  const resolvedMapping = mappingPath ? path.resolve(mappingPath) : undefined;
+  if (resolvedMapping && !fs.existsSync(resolvedMapping)) {
+    return { exitCode: 2, reason: `mapping file not found: ${resolvedMapping}` };
+  }
+
+  const resolvedNative = nativeSymbolsPath ? path.resolve(nativeSymbolsPath) : undefined;
+  if (resolvedNative && !fs.existsSync(resolvedNative)) {
+    return { exitCode: 2, reason: `native-symbols file not found: ${resolvedNative}` };
+  }
+
+  return {
+    exitCode: 0,
+    config: {
+      endpoint,
+      appId,
+      stackId,
+      apiKey,
+      bundleId: formatAndroidSymbolsBundleId(applicationId, versionCode, versionName),
+      mappingPath: resolvedMapping,
+      nativeSymbolsPath: resolvedNative,
+    },
+  };
+}
+
+/**
+ * Builds the multipart `curl` command used to POST Android symbol artifacts.
+ * Exported for testing. `curl -F` sets `Content-Type: multipart/form-data`
+ * automatically, so no explicit content-type header is added.
+ */
+export function buildAndroidSymbolsCurlCommand(config: ResolvedConfig, opts: AndroidSymbolsUploadOptions): string {
+  const normalizedEndpoint = config.endpoint.replace(/\/$/, '');
+  const url = `${normalizedEndpoint}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
+
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${config.stackId}:${config.apiKey}`,
+  };
+  // Local dev (noop auth) derives the stack from X-Scope-OrgID instead of the token.
+  if (isLocalEndpoint(url)) {
+    headers['X-Scope-OrgID'] = config.stackId;
+  }
+
+  const headerArgs = Object.entries(headers)
+    .map(([key, value]) => `-H "${key}: ${value}"`)
+    .join(' ');
+
+  const formArgs: string[] = [];
+  if (config.mappingPath) {
+    formArgs.push(`-F "mapping=@${config.mappingPath};type=text/plain"`);
+  }
+  if (config.nativeSymbolsPath) {
+    formArgs.push(`-F "native-symbols=@${config.nativeSymbolsPath};type=application/zip"`);
+  }
+
+  const proxyArg = opts.proxy ? `--proxy "${opts.proxy}"` : '';
+  const proxyUserArg = opts.proxyUser ? `--proxy-user "${opts.proxyUser}"` : '';
+
+  // -w prints the HTTP status code on its own trailing line so we can detect failures.
+  return `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} ${formArgs.join(' ')}`
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Resolves config, then uploads the Android symbol artifacts via `curl`.
+ *
+ * Returns a numeric exit code (so it is easy to test and the commander action
+ * can `process.exit` on non-zero):
+ *   - 0 success
+ *   - 1 upload failure (non-2xx response or curl error)
+ *   - 2 fatal config/validation error
+ */
+export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions): Promise<number> => {
+  const resolved = resolveConfig(opts);
+  if (!resolved.config) {
+    process.stderr.write(`${resolved.reason ?? 'Validation failed.'}\n`);
+    return resolved.exitCode;
+  }
+
+  const config = resolved.config;
+  const command = buildAndroidSymbolsCurlCommand(config, opts);
+  const targetUrl = `${config.endpoint.replace(/\/$/, '')}/app/${config.appId}/symbols/android/${encodeURIComponent(config.bundleId)}`;
+
+  const artifactList = [
+    config.mappingPath ? `mapping=${path.basename(config.mappingPath)}` : null,
+    config.nativeSymbolsPath ? `native-symbols=${path.basename(config.nativeSymbolsPath)}` : null,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  if (opts.dryRun) {
+    process.stdout.write(
+      `[dry-run] would upload Android symbols (${artifactList}) for ${config.bundleId} to ${targetUrl}\n`
+    );
+    opts.verbose && process.stdout.write(`[dry-run] ${command}\n`);
+    return 0;
+  }
+
+  opts.verbose &&
+    consoleInfoOrange(
+      `Uploading Android symbols (${artifactList}) for ${config.bundleId} to ${targetUrl}`
+    );
+
+  try {
+    const result = execSync(command, { encoding: 'utf8' });
+    const lines = result.trim().split('\n');
+    const statusCode = Number.parseInt(lines[lines.length - 1] ?? '', 10);
+    const body = lines.slice(0, -1).join('\n').trim();
+
+    if (Number.isNaN(statusCode) || statusCode < 200 || statusCode >= 300) {
+      process.stderr.write(`Android symbols upload failed (HTTP ${lines[lines.length - 1] ?? '?'}).\n`);
+      if (body) {
+        process.stderr.write(`${body}\n`);
+      }
+      return 1;
+    }
+
+    process.stdout.write(`Upload complete (HTTP ${statusCode}).\n`);
+    return 0;
+  } catch (error) {
+    process.stderr.write(`Error executing curl command: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+};

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -68,20 +68,6 @@ function redactCredential(value: string): string {
   return value.substring(0, 4) + '****';
 }
 
-function redactBearerToken(stackId: string, apiKey: string): string {
-  return `Bearer ${redactCredential(stackId)}:${redactCredential(apiKey)}`;
-}
-
-function buildVerboseCurlCommand(command: string, config: ResolvedConfig): string {
-  let redacted = command;
-  const rawBearerToken = `Bearer ${config.stackId}:${config.apiKey}`;
-  redacted = redacted.split(rawBearerToken).join(redactBearerToken(config.stackId, config.apiKey));
-  if (command.includes('--proxy-user')) {
-    redacted = redacted.replace(/--proxy-user "([^"]+)"/g, '--proxy-user "****"');
-  }
-  return redacted;
-}
-
 interface ResolvedConfig {
   endpoint: string;
   appId: string;
@@ -182,12 +168,13 @@ function resolveConfig(opts: AndroidSymbolsUploadOptions): ResolveResult {
 
 export interface AndroidSymbolsUploadRequest {
   label: string;
-  curlCommand: string;
+  curlCommand: string; // For verbose/dry-run display only
+  curlArgs: string[];  // Actual args array for execFileSync
   localBytes: number;
 }
 
 /**
- * Builds curl commands for mapping (optional) and each ABI zip (when native symbols provided).
+ * Builds curl args arrays for mapping (optional) and each ABI zip (when native symbols provided).
  * Exported for testing.
  */
 export function buildAndroidSymbolsUploadRequests(
@@ -196,12 +183,6 @@ export function buildAndroidSymbolsUploadRequests(
   abiArtifacts: AbiZipArtifact[] = []
 ): AndroidSymbolsUploadRequest[] {
   const normalizedEndpoint = config.endpoint.replace(/\/$/, '');
-  
-  // Validate URL to prevent command injection
-  if (normalizedEndpoint.includes('"') || normalizedEndpoint.includes('`') || normalizedEndpoint.includes('$')) {
-    throw new Error('Invalid endpoint URL: contains shell metacharacters');
-  }
-  
   const url = `${normalizedEndpoint}/app/${encodeURIComponent(config.appId)}/symbols/android/${encodeURIComponent(config.bundleId)}`;
 
   const headers: Record<string, string> = {
@@ -211,40 +192,49 @@ export function buildAndroidSymbolsUploadRequests(
     headers['X-Scope-OrgID'] = config.stackId;
   }
 
-  const headerArgs = Object.entries(headers)
-    .map(([key, value]) => `-H "${key}: ${value}"`)
-    .join(' ');
-
-  // Validate proxy and credentials don't contain shell metacharacters (use safer string methods instead of regex to avoid ReDoS)
-  const shellMetachars = ['"', '`', '$'];
-  if (opts.proxy && shellMetachars.some(char => opts.proxy!.includes(char))) {
-    throw new Error('Invalid proxy URL: contains shell metacharacters');
+  // Build base curl args array directly (no string concatenation/parsing)
+  const baseArgs: string[] = ['-sS', '-w', `\n%{http_code}`, '-X', 'POST'];
+  
+  if (opts.proxy) {
+    baseArgs.push('--proxy', opts.proxy);
   }
-  if (opts.proxyUser && shellMetachars.some(char => opts.proxyUser!.includes(char))) {
-    throw new Error('Invalid proxy credentials: contains shell metacharacters');
+  
+  if (opts.proxyUser) {
+    baseArgs.push('--proxy-user', opts.proxyUser);
   }
-  const proxyArg = opts.proxy ? `--proxy "${opts.proxy}"` : '';
-  const proxyUserArg = opts.proxyUser ? `--proxy-user "${opts.proxyUser}"` : '';
-  const baseCurl = `curl -s -w "\\n%{http_code}" -X POST ${proxyArg} ${proxyUserArg}`.replace(/\s+/g, ' ').trim();
+  
+  baseArgs.push(url);
+  
+  for (const [key, value] of Object.entries(headers)) {
+    baseArgs.push('-H', `${key}: ${value}`);
+  }
 
   const requests: AndroidSymbolsUploadRequest[] = [];
 
   if (config.mappingPath) {
     const mappingBytes = fs.statSync(config.mappingPath).size;
+    const args = [...baseArgs, '-F', `mapping=@${config.mappingPath};type=text/plain`];
+    
     requests.push({
       label: 'mapping',
       localBytes: mappingBytes,
-      curlCommand: `${baseCurl} "${url}" ${headerArgs} -F "mapping=@\\"${config.mappingPath}\\";type=text/plain"`,
+      curlArgs: args,
+      curlCommand: buildDisplayCommand(args, config, opts),
     });
   }
 
   for (const artifact of abiArtifacts) {
+    const args = [
+      ...baseArgs,
+      '-F', `abi=${artifact.abi}`,
+      '-F', `native-symbols=@${artifact.zipPath};type=application/zip`,
+    ];
+    
     requests.push({
       label: `native-symbols (${artifact.abi})`,
       localBytes: artifact.bytes,
-      curlCommand:
-        `${baseCurl} "${url}" ${headerArgs} -F "abi=${artifact.abi}" ` +
-        `-F "native-symbols=@\\"${artifact.zipPath}\\";type=application/zip"`,
+      curlArgs: args,
+      curlCommand: buildDisplayCommand(args, config, opts),
     });
   }
 
@@ -252,67 +242,34 @@ export function buildAndroidSymbolsUploadRequests(
 }
 
 /**
- * Executes curl command and parses HTTP status from output.
+ * Builds a display-friendly curl command string for verbose/dry-run output.
+ * Redacts credentials and quotes arguments for readability.
+ */
+function buildDisplayCommand(args: string[], config: ResolvedConfig, opts: AndroidSymbolsUploadOptions): string {
+  const displayArgs = args.map((arg, i) => {
+    // Redact Bearer token
+    if (arg.startsWith('Authorization: Bearer ')) {
+      return `Authorization: Bearer ${redactCredential(config.stackId)}:${redactCredential(config.apiKey)}`;
+    }
+    // Redact proxy credentials
+    if (args[i - 1] === '--proxy-user') {
+      return '****';
+    }
+    // Quote arguments with spaces or special chars for display
+    if (arg.includes(' ') || arg.includes('@')) {
+      return `"${arg}"`;
+    }
+    return arg;
+  });
+  
+  return `curl ${displayArgs.join(' ')}`;
+}
+
+/**
+ * Executes curl with the given args array and parses HTTP status from output.
  * Uses execFileSync to avoid shell interpretation and prevent command injection.
  */
-function runCurl(command: string): { statusCode: number; body: string } {
-  // Parse curl command string into arguments array for execFileSync
-  // The command format is: curl -s -w "\n%{http_code}" ... [args]
-  const args: string[] = [];
-  
-  // Extract arguments from command string (skip 'curl' prefix if present)
-  const cmdString = command.startsWith('curl ') ? command.substring(5) : command;
-  
-  // Simple argument parser that handles quoted strings
-  let current = '';
-  let inQuote = false;
-  let escapeNext = false;
-  
-  for (let i = 0; i < cmdString.length; i++) {
-    const char = cmdString[i];
-    
-    if (escapeNext) {
-      current += char;
-      escapeNext = false;
-      continue;
-    }
-    
-    // Only treat backslash as escape for sequences the command builder emits (e.g., \" for literal quotes)
-    // Otherwise preserve backslashes verbatim to support:
-    // - curl's -w "\\n%{http_code}" format
-    // - Windows file paths like C:\\Users\\...
-    if (char === '\\') {
-      const nextChar = cmdString[i + 1];
-      if (nextChar === '"') {
-        // Escape sequence for literal quote - consume backslash and set escape flag
-        escapeNext = true;
-        continue;
-      }
-      // Not an escape sequence we emit - preserve the backslash
-      current += char;
-      continue;
-    }
-    
-    if (char === '"') {
-      inQuote = !inQuote;
-      continue;
-    }
-    
-    if (char === ' ' && !inQuote) {
-      if (current) {
-        args.push(current);
-        current = '';
-      }
-      continue;
-    }
-    
-    current += char;
-  }
-  
-  if (current) {
-    args.push(current);
-  }
-  
+function runCurl(args: string[]): { statusCode: number; body: string } {
   const result = execFileSync('curl', args, { encoding: 'utf8' });
   const lines = result.trim().split('\n');
   const statusCode = Number.parseInt(lines[lines.length - 1] ?? '', 10);
@@ -355,8 +312,7 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
         `[dry-run] would upload ${req.label} (${req.localBytes} bytes) for ${config.bundleId} to ${targetUrl}\n`
       );
       if (opts.verbose) {
-        const redacted = buildVerboseCurlCommand(req.curlCommand, config);
-        process.stdout.write(`[dry-run] ${redacted}\n`);
+        process.stdout.write(`[dry-run] ${req.curlCommand}\n`);
       }
     }
     if (tempDir) {
@@ -371,7 +327,8 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
   try {
     for (const req of requests) {
       opts.verbose && process.stdout.write(`[Faro] uploading ${req.label} (${req.localBytes} bytes)\n`);
-      const { statusCode, body } = runCurl(req.curlCommand);
+      opts.verbose && process.stdout.write(`[Faro] ${req.curlCommand}\n`);
+      const { statusCode, body } = runCurl(req.curlArgs);
       if (Number.isNaN(statusCode) || statusCode < 200 || statusCode >= 300) {
         process.stderr.write(`Android symbols upload failed for ${req.label} (HTTP ${statusCode}).\n`);
         if (body) {

--- a/packages/faro-cli/src/androidSymbols.ts
+++ b/packages/faro-cli/src/androidSymbols.ts
@@ -294,6 +294,9 @@ export const runAndroidSymbolsUpload = async (opts: AndroidSymbolsUploadOptions)
         process.stdout.write(`[dry-run] ${redacted}\n`);
       }
     }
+    if (tempDir) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
     return 0;
   }
 

--- a/packages/faro-cli/src/cli.ts
+++ b/packages/faro-cli/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import { uploadSourceMaps, generateCurlCommand, injectBundleId, injectGitHash } from './index';
 import { runMetroUpload } from './metro';
+import { runAndroidSymbolsUpload } from './androidSymbols';
 import { consoleInfoOrange, exportBundleIdToFile, JS_SOURCEMAP_PATTERN, randomString, cleanAppName, resolveGitHash } from '@grafana/faro-bundlers-shared';
 import path from 'path';
 import fs from 'fs';
@@ -354,7 +355,10 @@ metro
   .option('-a, --app-id <id>', 'Faro app id (env: FARO_SOURCEMAP_APP_ID)')
   .option('-s, --stack-id <id>', 'Grafana Cloud stack id (env: FARO_SOURCEMAP_STACK_ID)')
   .option('-k, --api-key <key>', 'Bearer API key (env: FARO_SOURCEMAP_API_KEY)')
-  .option('-b, --bundle-id <id>', 'Bundle id matching the shipped JS bundle (env: FARO_BUNDLE_ID)')
+  .option(
+    '-b, --bundle-id <id>',
+    'Bundle id matching the shipped JS bundle (env: FARO_BUNDLE_ID). On Android React Native with com.grafana.faro, omit — Gradle supplies applicationId@versionCode@versionName via @grafana/faro-metro-plugin.',
+  )
   .option('--no-gzip', 'POST the raw .map JSON instead of a gzipped tarball')
   .option('-v, --verbose', 'Verbose logging', false)
   .option('--dry-run', 'Show what would be uploaded and exit', false)
@@ -372,14 +376,15 @@ Examples:
       --api-key  "$FARO_SOURCEMAP_API_KEY" \\
       --bundle-id "$FARO_BUNDLE_ID"
 
-  # Env fallbacks (when the surrounding shell already exports FARO_*)
+  # Env fallbacks (iOS / manual re-upload; Android RN release builds should use Gradle + faro-metro-plugin instead)
   $ FARO_SOURCEMAP_ENDPOINT=… FARO_SOURCEMAP_APP_ID=… FARO_SOURCEMAP_STACK_ID=… \\
-    FARO_SOURCEMAP_API_KEY=…   FARO_BUNDLE_ID=$(git rev-parse HEAD) \\
-    faro-cli metro upload --map path/to/your.map
+    FARO_SOURCEMAP_API_KEY=… faro-cli metro upload --map path/to/your.map --bundle-id "<your-ios-bundle-id>"
 
 Resolution: each connection setting and the bundle id come from the matching
 CLI flag (preferred) or the FARO_* env var (fallback). The path to the map
-is required (--map); this command never tries to construct it.`)
+is required (--map); this command never tries to construct it. On Android,
+prefer ./gradlew assembleRelease with the Faro Gradle plugin so bundle id
+matches R8 symbol uploads without exporting FARO_BUNDLE_ID.`)
   .action(async (options: {
     map: string;
     endpoint?: string;
@@ -407,6 +412,84 @@ is required (--map); this command never tries to construct it.`)
         verbose: !!options.verbose,
         dryRun: !!options.dryRun,
         maxUploadSize: options.maxUploadSize,
+        proxy: options.proxy,
+        proxyUser: options.proxyUser,
+      });
+      if (code !== 0) {
+        process.exit(code);
+      }
+    } catch (err) {
+      console.error('Error:', err instanceof Error ? err.message : err);
+      process.exit(1);
+    }
+  });
+
+const android = program
+  .command('android')
+  .description('Android native crash symbolication commands');
+
+android
+  .command('upload')
+  .description('Upload Android symbol artifacts (R8 mapping.txt and/or native-debug-symbols.zip) to the Faro API')
+  .option('--mapping <path>', 'Path to the R8/ProGuard mapping.txt')
+  .option('--native-symbols <path>', 'Path to the native-debug-symbols.zip')
+  .option('-e, --endpoint <url>', 'Faro API base URL (env: FARO_SOURCEMAP_ENDPOINT)')
+  .option('-a, --app-id <id>', 'Faro app id (env: FARO_SOURCEMAP_APP_ID)')
+  .option('-s, --stack-id <id>', 'Grafana Cloud stack id (env: FARO_SOURCEMAP_STACK_ID)')
+  .option('-k, --api-key <key>', 'Bearer API key (env: FARO_SOURCEMAP_API_KEY)')
+  .option('--application-id <id>', 'Android applicationId (env: FARO_ANDROID_APPLICATION_ID)')
+  .option('--version-code <code>', 'Android versionCode (env: FARO_ANDROID_VERSION_CODE)')
+  .option('--version-name <name>', 'Android versionName (env: FARO_ANDROID_VERSION_NAME)')
+  .option('-v, --verbose', 'Verbose logging', false)
+  .option('--dry-run', 'Show what would be uploaded and exit', false)
+  .option('-x, --proxy <url>', 'Proxy URL to use for cURL requests')
+  .option('-U, --proxy-user <user:password>', 'Username and password for proxy authentication')
+  .addHelpText('after', `
+Examples:
+  # Upload an R8 mapping and native debug symbols
+  $ faro-cli android upload \\
+      --mapping app/build/outputs/mapping/release/mapping.txt \\
+      --native-symbols app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip \\
+      --endpoint "$FARO_SOURCEMAP_ENDPOINT" \\
+      --app-id   "$FARO_SOURCEMAP_APP_ID" \\
+      --stack-id "$FARO_SOURCEMAP_STACK_ID" \\
+      --api-key  "$FARO_SOURCEMAP_API_KEY" \\
+      --application-id com.grafana.quickpizza \\
+      --version-code 42 \\
+      --version-name 1.0
+
+The encoded bundle id (applicationId@versionCode@versionName) must match meta.app.bundleId on
+app reports in meta.app so the collector can locate this mapping when retracing
+a crash. Connection and identity settings each fall back to the matching FARO_*
+env var. At least one of --mapping or --native-symbols is required.`)
+  .action(async (options: {
+    mapping?: string;
+    nativeSymbols?: string;
+    endpoint?: string;
+    appId?: string;
+    stackId?: string;
+    apiKey?: string;
+    applicationId?: string;
+    versionCode?: string;
+    versionName?: string;
+    verbose: boolean;
+    dryRun: boolean;
+    proxy?: string;
+    proxyUser?: string;
+  }) => {
+    try {
+      const code = await runAndroidSymbolsUpload({
+        mapping: options.mapping,
+        nativeSymbols: options.nativeSymbols,
+        endpoint: options.endpoint,
+        appId: options.appId,
+        stackId: options.stackId,
+        apiKey: options.apiKey,
+        applicationId: options.applicationId,
+        versionCode: options.versionCode,
+        versionName: options.versionName,
+        verbose: !!options.verbose,
+        dryRun: !!options.dryRun,
         proxy: options.proxy,
         proxyUser: options.proxyUser,
       });

--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -169,27 +169,30 @@ const executeCurl = (
     curlArgs.push('--data-binary', `@${fileToUpload}`);
 
     // Execute curl without invoking a shell
-    const result = execFileSync('curl', curlArgs, { encoding: 'utf8' });
+    // Use try-finally to ensure temp file cleanup even if execFileSync throws
+    try {
+      const result = execFileSync('curl', curlArgs, { encoding: 'utf8' });
 
-    // Clean up temporary file if created
-    if (tempFile && fs.existsSync(tempFile)) {
-      fs.unlinkSync(tempFile);
+      const markerIndex = result.lastIndexOf(CURL_HTTP_STATUS_MARKER);
+      const body = markerIndex >= 0 ? result.slice(0, markerIndex).trimEnd() : result.trimEnd();
+      const statusText = markerIndex >= 0 ? result.slice(markerIndex + CURL_HTTP_STATUS_MARKER.length).trim() : '';
+      const httpStatus = Number.parseInt(statusText, 10);
+
+      if (!Number.isFinite(httpStatus) || httpStatus < 200 || httpStatus >= 300) {
+        const detail = body.trim();
+        console.error(
+          `Error: source map upload failed with HTTP ${Number.isFinite(httpStatus) ? httpStatus : 'unknown'}${detail ? ` — ${detail}` : ''}`
+        );
+        return false;
+      }
+
+      return true;
+    } finally {
+      // Clean up temporary file if created (runs even if execFileSync throws)
+      if (tempFile && fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
     }
-
-    const markerIndex = result.lastIndexOf(CURL_HTTP_STATUS_MARKER);
-    const body = markerIndex >= 0 ? result.slice(0, markerIndex).trimEnd() : result.trimEnd();
-    const statusText = markerIndex >= 0 ? result.slice(markerIndex + CURL_HTTP_STATUS_MARKER.length).trim() : '';
-    const httpStatus = Number.parseInt(statusText, 10);
-
-    if (!Number.isFinite(httpStatus) || httpStatus < 200 || httpStatus >= 300) {
-      const detail = body.trim();
-      console.error(
-        `Error: source map upload failed with HTTP ${Number.isFinite(httpStatus) ? httpStatus : 'unknown'}${detail ? ` — ${detail}` : ''}`
-      );
-      return false;
-    }
-
-    return true;
   } catch (error) {
     console.error('Error executing cURL command:', error);
     return false;

--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -177,11 +177,6 @@ const executeCurl = (
       return false;
     }
 
-    if (body.toLowerCase().includes('error')) {
-      console.error(`Error in cURL response body: ${body}`);
-      return false;
-    }
-
     return true;
   } catch (error) {
     console.error('Error executing cURL command:', error);

--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { create } from 'tar';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { consoleInfoOrange, THIRTY_MB_IN_BYTES, faroBundleIdSnippet, faroGitHashSnippet, ensureSourceMapFileProperties, isLocalEndpoint } from '@grafana/faro-bundlers-shared';
 import { gzipSync } from 'zlib';
 import { tmpdir } from 'os';
@@ -142,22 +142,34 @@ const executeCurl = (
       fileToUpload = tempFile;
     }
 
-    // Build headers string for curl command
-    const headerArgs = Object.entries({
+    // Build headers for curl command
+    const uploadHeaders = Object.entries({
       ...headers,
       'Content-Type': finalContentType,
       ...(gzipPayload && !contentType.includes('gzip') ? { 'Content-Encoding': 'gzip' } : {})
-    })
-      .map(([key, value]) => `-H "${key}: ${value}"`)
-      .join(' ');
+    });
 
-    // Build the curl command
-    const proxyArg = proxy ? `--proxy "${proxy}"` : '';
-    const proxyUserArg = proxyUser ? `--proxy-user "${proxyUser}"` : '';
-    const curlCommand = `curl -sS -w "\n${CURL_HTTP_STATUS_MARKER}%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} --data-binary @"${fileToUpload}"`;
+    // Build curl arguments (avoid shell interpretation)
+    const curlArgs: string[] = ['-sS', '-w', `\n${CURL_HTTP_STATUS_MARKER}%{http_code}`, '-X', 'POST'];
 
-    // Execute the curl command
-    const result = execSync(curlCommand, { encoding: 'utf8' });
+    if (proxy) {
+      curlArgs.push('--proxy', proxy);
+    }
+
+    if (proxyUser) {
+      curlArgs.push('--proxy-user', proxyUser);
+    }
+
+    curlArgs.push(url);
+
+    for (const [key, value] of uploadHeaders) {
+      curlArgs.push('-H', `${key}: ${value}`);
+    }
+
+    curlArgs.push('--data-binary', `@${fileToUpload}`);
+
+    // Execute curl without invoking a shell
+    const result = execFileSync('curl', curlArgs, { encoding: 'utf8' });
 
     // Clean up temporary file if created
     if (tempFile && fs.existsSync(tempFile)) {

--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { create } from 'tar';
 import { execSync } from 'child_process';
-import { consoleInfoOrange, THIRTY_MB_IN_BYTES, faroBundleIdSnippet, faroGitHashSnippet, ensureSourceMapFileProperties } from '@grafana/faro-bundlers-shared';
+import { consoleInfoOrange, THIRTY_MB_IN_BYTES, faroBundleIdSnippet, faroGitHashSnippet, ensureSourceMapFileProperties, isLocalEndpoint } from '@grafana/faro-bundlers-shared';
 import { gzipSync } from 'zlib';
 import { tmpdir } from 'os';
 
@@ -81,6 +81,20 @@ const createGzippedFile = (filePath: string): string => {
  * @param maxSize Optional custom max size in bytes (defaults to 30MB)
  * @returns boolean indicating if the file exceeds the size limit
  */
+
+
+const buildUploadHeaders = (url: string, stackId: string, apiKey: string): Record<string, string> => {
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${stackId}:${apiKey}`,
+  };
+  if (isLocalEndpoint(url)) {
+    headers['X-Scope-OrgID'] = String(stackId);
+  }
+  return headers;
+};
+
+const CURL_HTTP_STATUS_MARKER = '__FARO_HTTP_STATUS__:';
+
 const exceedsMaxSize = (filePath: string, maxSize?: number): boolean => {
   const { size } = fs.statSync(filePath);
   const maxAllowedSize = maxSize && maxSize > 0 ? maxSize : THIRTY_MB_IN_BYTES;
@@ -140,7 +154,7 @@ const executeCurl = (
     // Build the curl command
     const proxyArg = proxy ? `--proxy "${proxy}"` : '';
     const proxyUserArg = proxyUser ? `--proxy-user "${proxyUser}"` : '';
-    const curlCommand = `curl -s -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} --data-binary @${fileToUpload}`;
+    const curlCommand = `curl -sS -w "\n${CURL_HTTP_STATUS_MARKER}%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} --data-binary @${fileToUpload}`;
 
     // Execute the curl command
     const result = execSync(curlCommand, { encoding: 'utf8' });
@@ -150,9 +164,21 @@ const executeCurl = (
       fs.unlinkSync(tempFile);
     }
 
-    // Check if the response contains an error
-    if (result && result.toLowerCase().includes('error')) {
-      console.error(`Error in cURL response: ${result}`);
+    const markerIndex = result.lastIndexOf(CURL_HTTP_STATUS_MARKER);
+    const body = markerIndex >= 0 ? result.slice(0, markerIndex).trimEnd() : result.trimEnd();
+    const statusText = markerIndex >= 0 ? result.slice(markerIndex + CURL_HTTP_STATUS_MARKER.length).trim() : '';
+    const httpStatus = Number.parseInt(statusText, 10);
+
+    if (!Number.isFinite(httpStatus) || httpStatus < 200 || httpStatus >= 300) {
+      const detail = body.trim();
+      console.error(
+        `Error: source map upload failed with HTTP ${Number.isFinite(httpStatus) ? httpStatus : 'unknown'}${detail ? ` — ${detail}` : ''}`
+      );
+      return false;
+    }
+
+    if (body.toLowerCase().includes('error')) {
+      console.error(`Error in cURL response body: ${body}`);
       return false;
     }
 
@@ -203,7 +229,7 @@ export const uploadSourceMap = async (
     success = executeCurl(
       sourcemapEndpoint,
       filePath,
-      { "Authorization": `Bearer ${stackId}:${apiKey}` },
+      buildUploadHeaders(sourcemapEndpoint, stackId, apiKey),
       "application/json",
       gzipPayload,
       maxUploadSize,
@@ -302,7 +328,7 @@ export const uploadCompressedSourceMaps = async (
     success = executeCurl(
       sourcemapEndpoint,
       tarball,
-      { "Authorization": `Bearer ${stackId}:${apiKey}` },
+      buildUploadHeaders(sourcemapEndpoint, stackId, apiKey),
       "application/gzip",
       false, // Don't gzip again as tarball is already compressed
       maxUploadSize,

--- a/packages/faro-cli/src/index.ts
+++ b/packages/faro-cli/src/index.ts
@@ -154,7 +154,7 @@ const executeCurl = (
     // Build the curl command
     const proxyArg = proxy ? `--proxy "${proxy}"` : '';
     const proxyUserArg = proxyUser ? `--proxy-user "${proxyUser}"` : '';
-    const curlCommand = `curl -sS -w "\n${CURL_HTTP_STATUS_MARKER}%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} --data-binary @${fileToUpload}`;
+    const curlCommand = `curl -sS -w "\n${CURL_HTTP_STATUS_MARKER}%{http_code}" -X POST ${proxyArg} ${proxyUserArg} "${url}" ${headerArgs} --data-binary @"${fileToUpload}"`;
 
     // Execute the curl command
     const result = execSync(curlCommand, { encoding: 'utf8' });

--- a/packages/faro-cli/src/metro.ts
+++ b/packages/faro-cli/src/metro.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import {
   consoleInfoOrange,
   ensureSourceMapFileProperty,
+  isLocalEndpoint,
   THIRTY_MB_IN_BYTES,
 } from '@grafana/faro-bundlers-shared';
 
@@ -209,7 +210,20 @@ export const runMetroUpload = async (opts: MetroUploadOptions): Promise<number> 
       });
 
   if (!ok) {
-    process.stderr.write('\nUpload failed. Re-run with --verbose for the response status.\n');
+    const hints = [
+      'Verify endpoint, app id, stack id, and API key (CLI flags or FARO_SOURCEMAP_* env vars).',
+    ];
+    if (isLocalEndpoint(normalizedEndpoint)) {
+      hints.push('Local stack: confirm the API key matches your Frontend Observability source map upload token.');
+    }
+    hints.push('Re-run with --verbose to see the HTTP status and response body.');
+
+    process.stderr.write(
+      `\n[Faro] ERROR: Metro composed source map upload failed.\n` +
+        `  endpoint : ${sourcemapEndpoint}\n` +
+        `  bundleId : ${bundleId}\n` +
+        hints.map((line) => `  ${line}\n`).join('')
+    );
     return 1;
   }
 

--- a/packages/faro-cli/src/nativeSymbolsByAbi.ts
+++ b/packages/faro-cli/src/nativeSymbolsByAbi.ts
@@ -88,7 +88,8 @@ export function packNativeSymbolsByAbi(agpZipPath: string, outputDir: string): A
     throw new Error(`no native .so entries found in ${agpZipPath}`);
   }
 
-  return artifacts;
+  // Sort artifacts by ABI name to match documented behavior
+  return artifacts.sort((a, b) => a.abi.localeCompare(b.abi));
 }
 
 function abiFromZipPath(name: string): NativeAbi | null {

--- a/packages/faro-cli/src/nativeSymbolsByAbi.ts
+++ b/packages/faro-cli/src/nativeSymbolsByAbi.ts
@@ -1,0 +1,252 @@
+import { createHash } from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { deflateRawSync, inflateRawSync } from 'zlib';
+
+/** AGP ABI folder names accepted on upload. */
+export const ALLOWED_NATIVE_ABIS = ['arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86', 'riscv64'] as const;
+
+export type NativeAbi = (typeof ALLOWED_NATIVE_ABIS)[number];
+
+export interface AbiZipArtifact {
+  abi: NativeAbi;
+  zipPath: string;
+  bytes: number;
+}
+
+interface ZipEntry {
+  name: string;
+  data: Buffer;
+}
+
+/** Reads AGP native-debug-symbols.zip entries ending in .so or .so.dbg. */
+export function readAgpNativeZip(zipBytes: Buffer): ZipEntry[] {
+  const entries: ZipEntry[] = [];
+  for (const entry of parseZipEntries(zipBytes)) {
+    const lower = entry.name.toLowerCase();
+    if (lower.endsWith('.so') || lower.endsWith('.so.dbg')) {
+      entries.push(entry);
+    }
+  }
+  return entries;
+}
+
+/** Groups zip entries by ABI folder and normalizes .so.dbg → .so inside {abi}/ paths. */
+export function groupEntriesByAbi(entries: ZipEntry[]): Map<NativeAbi, Map<string, Buffer>> {
+  const byAbi = new Map<NativeAbi, Map<string, Buffer>>();
+
+  for (const entry of entries) {
+    const abi = abiFromZipPath(entry.name);
+    if (!abi) {
+      continue;
+    }
+    let libName = path.basename(entry.name);
+    if (libName.endsWith('.so.dbg')) {
+      libName = libName.slice(0, -4);
+    }
+    if (!libName.endsWith('.so')) {
+      continue;
+    }
+    const zipPath = `${abi}/${libName}`;
+    if (!byAbi.has(abi)) {
+      byAbi.set(abi, new Map());
+    }
+    byAbi.get(abi)!.set(zipPath, entry.data);
+  }
+
+  return byAbi;
+}
+
+/** Builds one Deflate-compressed zip per ABI. */
+export function buildAbiZip(libs: Map<string, Buffer>): Buffer {
+  const entries = [...libs.entries()].sort(([a], [b]) => a.localeCompare(b));
+  return createDeflateZip(entries);
+}
+
+/**
+ * Splits AGP native-debug-symbols.zip into per-ABI zips under outputDir.
+ * Returns artifacts sorted by ABI name.
+ */
+export function packNativeSymbolsByAbi(agpZipPath: string, outputDir: string): AbiZipArtifact[] {
+  const zipBytes = fs.readFileSync(agpZipPath);
+  const grouped = groupEntriesByAbi(readAgpNativeZip(zipBytes));
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const artifacts: AbiZipArtifact[] = [];
+  for (const abi of ALLOWED_NATIVE_ABIS) {
+    const libs = grouped.get(abi);
+    if (!libs || libs.size === 0) {
+      continue;
+    }
+    const outPath = path.join(outputDir, `${abi}.zip`);
+    const payload = buildAbiZip(libs);
+    fs.writeFileSync(outPath, payload);
+    artifacts.push({ abi, zipPath: outPath, bytes: payload.length });
+  }
+
+  if (artifacts.length === 0) {
+    throw new Error(`no native .so entries found in ${agpZipPath}`);
+  }
+
+  return artifacts;
+}
+
+function abiFromZipPath(name: string): NativeAbi | null {
+  const clean = name.replace(/\\/g, '/');
+  const parts = clean.split('/').filter(Boolean);
+  if (parts.length < 2) {
+    return null;
+  }
+  let candidate = parts[parts.length - 2];
+  if (candidate === 'obj' && parts.length >= 3) {
+    candidate = parts[parts.length - 3];
+  }
+  return ALLOWED_NATIVE_ABIS.includes(candidate as NativeAbi) ? (candidate as NativeAbi) : null;
+}
+
+function parseZipEntries(buffer: Buffer): ZipEntry[] {
+  const eocdOffset = findEocdOffset(buffer);
+  if (eocdOffset < 0) {
+    throw new Error('invalid zip: EOCD not found');
+  }
+
+  const totalEntries = buffer.readUInt16LE(eocdOffset + 10);
+  const centralDirOffset = buffer.readUInt32LE(eocdOffset + 16);
+  const entries: ZipEntry[] = [];
+
+  let offset = centralDirOffset;
+  for (let i = 0; i < totalEntries; i++) {
+    if (buffer.readUInt32LE(offset) !== 0x02014b50) {
+      throw new Error('invalid zip central directory');
+    }
+    const compression = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const uncompressedSize = buffer.readUInt32LE(offset + 24);
+    const nameLen = buffer.readUInt16LE(offset + 28);
+    const extraLen = buffer.readUInt16LE(offset + 30);
+    const commentLen = buffer.readUInt16LE(offset + 32);
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42);
+    const name = buffer.subarray(offset + 46, offset + 46 + nameLen).toString('utf8');
+    offset += 46 + nameLen + extraLen + commentLen;
+
+    const localNameLen = buffer.readUInt16LE(localHeaderOffset + 26);
+    const localExtraLen = buffer.readUInt16LE(localHeaderOffset + 28);
+    const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+    const compressed = buffer.subarray(dataStart, dataStart + compressedSize);
+
+    let data: Buffer;
+    if (compression === 0) {
+      data = Buffer.from(compressed);
+    } else if (compression === 8) {
+      data = inflateRawCompat(compressed, uncompressedSize);
+    } else {
+      throw new Error(`unsupported zip compression ${compression} for ${name}`);
+    }
+
+    entries.push({ name, data });
+  }
+
+  return entries;
+}
+
+function inflateRawCompat(compressed: Buffer, expectedSize: number): Buffer {
+  const out = inflateRawSync(compressed);
+  if (expectedSize > 0 && out.length !== expectedSize) {
+    throw new Error(`unexpected inflated size for zip entry: got ${out.length}, want ${expectedSize}`);
+  }
+  return out;
+}
+
+function findEocdOffset(buffer: Buffer): number {
+  const minEocd = 22;
+  for (let i = buffer.length - minEocd; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === 0x06054b50) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/** @internal Exported for unit tests — builds a deflate zip from path/content pairs. */
+export function buildZipFromEntries(entries: Array<[string, Buffer]>): Buffer {
+  return createDeflateZip(entries);
+}
+
+function createDeflateZip(entries: Array<[string, Buffer]>): Buffer {
+  const parts: Buffer[] = [];
+  const central: Buffer[] = [];
+  let offset = 0;
+
+  for (const [name, data] of entries) {
+    const nameBuf = Buffer.from(name, 'utf8');
+    const compressed = deflateRawSync(data);
+    const crc = crc32(data);
+
+    const local = Buffer.alloc(30 + nameBuf.length);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt16LE(8, 6);
+    local.writeUInt16LE(0, 8);
+    local.writeUInt16LE(0, 10);
+    local.writeUInt32LE(crc, 14);
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(data.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    local.writeUInt16LE(0, 28);
+    nameBuf.copy(local, 30);
+
+    const centralEntry = Buffer.alloc(46 + nameBuf.length);
+    centralEntry.writeUInt32LE(0x02014b50, 0);
+    centralEntry.writeUInt16LE(20, 4);
+    centralEntry.writeUInt16LE(20, 6);
+    centralEntry.writeUInt16LE(8, 8);
+    centralEntry.writeUInt16LE(0, 10);
+    centralEntry.writeUInt16LE(0, 12);
+    centralEntry.writeUInt32LE(crc, 16);
+    centralEntry.writeUInt32LE(compressed.length, 20);
+    centralEntry.writeUInt32LE(data.length, 24);
+    centralEntry.writeUInt16LE(nameBuf.length, 28);
+    centralEntry.writeUInt16LE(0, 30);
+    centralEntry.writeUInt16LE(0, 32);
+    centralEntry.writeUInt16LE(0, 34);
+    centralEntry.writeUInt16LE(0, 36);
+    centralEntry.writeUInt32LE(0, 38);
+    centralEntry.writeUInt32LE(offset, 42);
+    nameBuf.copy(centralEntry, 46);
+
+    parts.push(local, compressed);
+    central.push(centralEntry);
+    offset += local.length + compressed.length;
+  }
+
+  const centralSize = central.reduce((sum, b) => sum + b.length, 0);
+  const centralStart = offset;
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(0, 4);
+  eocd.writeUInt16LE(0, 6);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralSize, 12);
+  eocd.writeUInt32LE(centralStart, 16);
+  eocd.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...parts, ...central, eocd]);
+}
+
+function crc32(data: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < data.length; i++) {
+    crc ^= data[i];
+    for (let j = 0; j < 8; j++) {
+      const mask = -(crc & 1);
+      crc = (crc >>> 1) ^ (0xedb88320 & mask);
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** Stable content hash helper for tests/logging. */
+export function sha256Hex(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -3,7 +3,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { buildAndroidSymbolsCurlCommand, runAndroidSymbolsUpload } from '../androidSymbols';
+import { buildAndroidSymbolsUploadRequests, runAndroidSymbolsUpload } from '../androidSymbols';
+import { buildTestAgpZip } from './helpers/buildTestAgpZip';
 
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
@@ -87,10 +88,10 @@ describe('runAndroidSymbolsUpload', () => {
     expect(code).toBe(0);
     expect(mockedExecSync).not.toHaveBeenCalled();
     const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(stdout).toMatch(/\[dry-run\] would upload Android symbols/);
+    expect(stdout).toMatch(/\[dry-run\] would upload mapping/);
   });
 
-  it('uploads and returns 0 on a 2xx response', async () => {
+  it('uploads mapping and returns 0 on a 2xx response', async () => {
     mockedExecSync.mockReturnValue('\n201' as never);
 
     const code = await runAndroidSymbolsUpload({
@@ -104,7 +105,7 @@ describe('runAndroidSymbolsUpload', () => {
     expect(mockedExecSync).toHaveBeenCalledTimes(1);
     expect(mockedExecSync).toHaveBeenCalledWith(expect.stringContaining('curl -s'), expect.any(Object));
     const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
-    expect(stdout).toMatch(/Upload complete \(HTTP 201\)/);
+    expect(stdout).toMatch(/Upload complete \(1 POSTs\)/);
   });
 
   it('returns 1 on a non-2xx response', async () => {
@@ -138,32 +139,74 @@ describe('runAndroidSymbolsUpload', () => {
   });
 });
 
-describe('buildAndroidSymbolsCurlCommand', () => {
-  const config = {
+describe('buildAndroidSymbolsUploadRequests', () => {
+  let localTempDir: string;
+  let localMappingPath: string;
+
+  beforeEach(() => {
+    localTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-android-req-'));
+    localMappingPath = path.join(localTempDir, 'mapping.txt');
+    fs.writeFileSync(localMappingPath, 'proguard mapping');
+  });
+
+  afterEach(() => {
+    fs.rmSync(localTempDir, { recursive: true, force: true });
+  });
+
+  const config = () => ({
     ...baseConnection,
     endpoint: 'https://e.test/',
-    mappingPath: '/abs/mapping.txt',
-    nativeSymbolsPath: '/abs/native-debug-symbols.zip',
+    mappingPath: localMappingPath,
+    nativeSymbolsPath: undefined as string | undefined,
     bundleId: 'com.grafana.quickpizza@42@1.0',
-  };
+  });
 
-  it('builds the symbols/android URL, auth header and multipart fields', () => {
-    const cmd = buildAndroidSymbolsCurlCommand(config, { verbose: false, dryRun: false });
-
+  it('builds mapping-only request with URL, auth, and mapping field', () => {
+    const requests = buildAndroidSymbolsUploadRequests(config(), { verbose: false, dryRun: false }, []);
+    expect(requests).toHaveLength(1);
+    expect(requests[0].label).toBe('mapping');
+    const cmd = requests[0].curlCommand;
     expect(cmd).toContain('"https://e.test/app/aid/symbols/android/com.grafana.quickpizza%4042%401.0"');
     expect(cmd).toContain('-H "Authorization: Bearer sid:secret"');
-    expect(cmd).toContain('-F "mapping=@/abs/mapping.txt;type=text/plain"');
-    expect(cmd).toContain('-F "native-symbols=@/abs/native-debug-symbols.zip;type=application/zip"');
+    expect(cmd).toContain(`-F "mapping=@${localMappingPath};type=text/plain"`);
     // Remote endpoint must not leak a stack-id header.
     expect(cmd).not.toContain('X-Scope-OrgID');
   });
 
   it('adds X-Scope-OrgID for local endpoints', () => {
-    const cmd = buildAndroidSymbolsCurlCommand(
-      { ...config, endpoint: 'http://localhost:8000' },
-      { verbose: false, dryRun: false }
+    const requests = buildAndroidSymbolsUploadRequests(
+      { ...config(), endpoint: 'http://localhost:8000' },
+      { verbose: false, dryRun: false },
+      [],
+    );
+    expect(requests[0].curlCommand).toContain('-H "X-Scope-OrgID: sid"');
+  });
+
+  it('builds per-ABI native requests with abi form field', () => {
+    const nativePath = path.join(localTempDir, 'native.zip');
+    fs.writeFileSync(
+      nativePath,
+      buildTestAgpZip([
+        ['arm64-v8a/liba.so', Buffer.alloc(8, 1)],
+        ['x86_64/libb.so', Buffer.alloc(8, 2)],
+      ]),
     );
 
-    expect(cmd).toContain('-H "X-Scope-OrgID: sid"');
+    const abiArtifacts = [
+      { abi: 'arm64-v8a' as const, zipPath: path.join(localTempDir, 'arm64-v8a.zip'), bytes: 100 },
+      { abi: 'x86_64' as const, zipPath: path.join(localTempDir, 'x86_64.zip'), bytes: 100 },
+    ];
+    fs.writeFileSync(abiArtifacts[0].zipPath, Buffer.alloc(100));
+    fs.writeFileSync(abiArtifacts[1].zipPath, Buffer.alloc(100));
+
+    const requests = buildAndroidSymbolsUploadRequests(
+      { ...config(), nativeSymbolsPath: nativePath },
+      { verbose: false, dryRun: false },
+      abiArtifacts,
+    );
+
+    expect(requests).toHaveLength(3);
+    expect(requests[1].curlCommand).toContain('-F "abi=arm64-v8a"');
+    expect(requests[2].curlCommand).toContain('-F "abi=x86_64"');
   });
 });

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -8,9 +8,11 @@ import { buildTestAgpZip } from './helpers/buildTestAgpZip';
 
 jest.mock('child_process', () => ({
   execSync: jest.fn(),
+  execFileSync: jest.fn(),
 }));
 
 const mockedExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockedExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
 
 const baseConnection = {
   endpoint: 'https://e.test/',
@@ -35,6 +37,9 @@ describe('runAndroidSymbolsUpload', () => {
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
     mockedExecSync.mockReset();
+    mockedExecFileSync.mockReset();
+    // Mock successful curl response by default
+    mockedExecFileSync.mockReturnValue('{"uploaded": true}\n201');
   });
 
   afterEach(() => {
@@ -51,7 +56,7 @@ describe('runAndroidSymbolsUpload', () => {
     });
 
     expect(code).toBe(2);
-    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
     const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(stderr).toMatch(/Missing required settings/);
   });
@@ -128,7 +133,7 @@ describe('runAndroidSymbolsUpload', () => {
     });
 
     expect(code).toBe(0);
-    expect(mockedExecSync).not.toHaveBeenCalled();
+    expect(mockedExecFileSync).not.toHaveBeenCalled();
     const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(stdout).toMatch(/\[dry-run\] would upload mapping/);
   });
@@ -149,7 +154,7 @@ describe('runAndroidSymbolsUpload', () => {
   });
 
   it('uploads mapping and returns 0 on a 2xx response', async () => {
-    mockedExecSync.mockReturnValue('\n201' as never);
+    mockedExecFileSync.mockReturnValue('\n201' as never);
 
     const code = await runAndroidSymbolsUpload({
       ...baseConnection,
@@ -159,14 +164,14 @@ describe('runAndroidSymbolsUpload', () => {
     });
 
     expect(code).toBe(0);
-    expect(mockedExecSync).toHaveBeenCalledTimes(1);
-    expect(mockedExecSync).toHaveBeenCalledWith(expect.stringContaining('curl -s'), expect.any(Object));
+    expect(mockedExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecFileSync).toHaveBeenCalledWith('curl', expect.any(Array), expect.any(Object));
     const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(stdout).toMatch(/Upload complete \(1 POSTs\)/);
   });
 
   it('returns 1 on a non-2xx response', async () => {
-    mockedExecSync.mockReturnValue('bad request\n400' as never);
+    mockedExecFileSync.mockReturnValue('bad request\n400' as never);
 
     const code = await runAndroidSymbolsUpload({
       ...baseConnection,
@@ -181,7 +186,7 @@ describe('runAndroidSymbolsUpload', () => {
   });
 
   it('returns 1 when curl throws', async () => {
-    mockedExecSync.mockImplementation(() => {
+    mockedExecFileSync.mockImplementation(() => {
       throw new Error('curl: command not found');
     });
 

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -64,6 +64,48 @@ describe('runAndroidSymbolsUpload', () => {
     expect(stderr).toMatch(/at least one of --mapping/i);
   });
 
+  it('returns 2 when applicationId contains @ character', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      applicationId: 'com.evil@inject',
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/cannot contain '@'/);
+  });
+
+  it('returns 2 when versionName contains @ character', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      versionName: '1.0@evil',
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/cannot contain '@'/);
+  });
+
+  it('returns 2 when versionCode is not an integer', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      versionCode: '42.5',
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/must be an integer/);
+  });
+
   it('returns 2 when the mapping file does not exist', async () => {
     const code = await runAndroidSymbolsUpload({
       ...baseConnection,
@@ -89,6 +131,21 @@ describe('runAndroidSymbolsUpload', () => {
     expect(mockedExecSync).not.toHaveBeenCalled();
     const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
     expect(stdout).toMatch(/\[dry-run\] would upload mapping/);
+  });
+
+  it('redacts credentials in verbose dry-run output', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: mappingPath,
+      verbose: true,
+      dryRun: true,
+    });
+
+    expect(code).toBe(0);
+    const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    // Credentials should be redacted
+    expect(stdout).not.toContain('sid:secret');
+    expect(stdout).toMatch(/Bearer.*\*\*\*\*/);
   });
 
   it('uploads mapping and returns 0 on a 2xx response', async () => {
@@ -159,6 +216,16 @@ describe('buildAndroidSymbolsUploadRequests', () => {
     mappingPath: localMappingPath,
     nativeSymbolsPath: undefined as string | undefined,
     bundleId: 'com.grafana.quickpizza@42@1.0',
+  });
+
+  it('throws when endpoint contains shell metacharacters', () => {
+    expect(() =>
+      buildAndroidSymbolsUploadRequests(
+        { ...config(), endpoint: 'https://e.test/`whoami`' },
+        { verbose: false, dryRun: false },
+        []
+      )
+    ).toThrow('shell metacharacters');
   });
 
   it('builds mapping-only request with URL, auth, and mapping field', () => {

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -7,11 +7,9 @@ import { buildAndroidSymbolsUploadRequests, runAndroidSymbolsUpload } from '../a
 import { buildTestAgpZip } from './helpers/buildTestAgpZip';
 
 jest.mock('child_process', () => ({
-  execSync: jest.fn(),
   execFileSync: jest.fn(),
 }));
 
-const mockedExecSync = execSync as jest.MockedFunction<typeof execSync>;
 const mockedExecFileSync = execFileSync as jest.MockedFunction<typeof execFileSync>;
 
 const baseConnection = {
@@ -36,7 +34,6 @@ describe('runAndroidSymbolsUpload', () => {
     fs.writeFileSync(mappingPath, 'com.example.Foo -> a:\n');
     stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
     stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
-    mockedExecSync.mockReset();
     mockedExecFileSync.mockReset();
     // Mock successful curl response by default
     mockedExecFileSync.mockReturnValue('{"uploaded": true}\n201');

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -235,7 +235,7 @@ describe('buildAndroidSymbolsUploadRequests', () => {
     const cmd = requests[0].curlCommand;
     expect(cmd).toContain('"https://e.test/app/aid/symbols/android/com.grafana.quickpizza%4042%401.0"');
     expect(cmd).toContain('-H "Authorization: Bearer sid:secret"');
-    expect(cmd).toContain(`-F "mapping=@${localMappingPath};type=text/plain"`);
+    expect(cmd).toContain(`-F "mapping=@\\"${localMappingPath}\\";type=text/plain"`);
     // Remote endpoint must not leak a stack-id header.
     expect(cmd).not.toContain('X-Scope-OrgID');
   });

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -220,26 +220,23 @@ describe('buildAndroidSymbolsUploadRequests', () => {
     bundleId: 'com.grafana.quickpizza@42@1.0',
   });
 
-  it('throws when endpoint contains shell metacharacters', () => {
-    expect(() =>
-      buildAndroidSymbolsUploadRequests(
-        { ...config(), endpoint: 'https://e.test/`whoami`' },
-        { verbose: false, dryRun: false },
-        []
-      )
-    ).toThrow('shell metacharacters');
-  });
-
   it('builds mapping-only request with URL, auth, and mapping field', () => {
     const requests = buildAndroidSymbolsUploadRequests(config(), { verbose: false, dryRun: false }, []);
     expect(requests).toHaveLength(1);
     expect(requests[0].label).toBe('mapping');
+    
+    // Check args array (used for execution)
+    const args = requests[0].curlArgs;
+    expect(args).toContain('https://e.test/app/aid/symbols/android/com.grafana.quickpizza%4042%401.0');
+    expect(args).toContain(`Authorization: Bearer sid:secret`);
+    expect(args).toContain(`mapping=@${localMappingPath};type=text/plain`);
+    // Remote endpoint must not leak a stack-id header
+    expect(args.some(arg => arg.includes('X-Scope-OrgID'))).toBe(false);
+    
+    // Check display command (for verbose output)
     const cmd = requests[0].curlCommand;
-    expect(cmd).toContain('"https://e.test/app/aid/symbols/android/com.grafana.quickpizza%4042%401.0"');
-    expect(cmd).toContain('-H "Authorization: Bearer sid:secret"');
-    expect(cmd).toContain(`-F "mapping=@\\"${localMappingPath}\\";type=text/plain"`);
-    // Remote endpoint must not leak a stack-id header.
-    expect(cmd).not.toContain('X-Scope-OrgID');
+    expect(cmd).toContain('curl');
+    expect(cmd).toContain('Authorization: Bearer');
   });
 
   it('adds X-Scope-OrgID for local endpoints', () => {
@@ -248,7 +245,8 @@ describe('buildAndroidSymbolsUploadRequests', () => {
       { verbose: false, dryRun: false },
       [],
     );
-    expect(requests[0].curlCommand).toContain('-H "X-Scope-OrgID: sid"');
+    const args = requests[0].curlArgs;
+    expect(args).toContain('X-Scope-OrgID: sid');
   });
 
   it('builds per-ABI native requests with abi form field', () => {
@@ -275,34 +273,18 @@ describe('buildAndroidSymbolsUploadRequests', () => {
     );
 
     expect(requests).toHaveLength(3);
-    expect(requests[1].curlCommand).toContain('-F "abi=arm64-v8a"');
-    expect(requests[2].curlCommand).toContain('-F "abi=x86_64"');
+    expect(requests[1].curlArgs).toContain('abi=arm64-v8a');
+    expect(requests[2].curlArgs).toContain('abi=x86_64');
   });
 
-  it('preserves backslash-n in curl -w format for HTTP status extraction', () => {
+  it('builds curl args array with proper -w flag format', () => {
     const requests = buildAndroidSymbolsUploadRequests(config(), { verbose: false, dryRun: false }, []);
     expect(requests).toHaveLength(1);
-    const cmd = requests[0].curlCommand;
-    // Verify the command contains the literal backslash-n sequence, not just 'n'
-    expect(cmd).toContain('-w "\\n%{http_code}"');
-    expect(cmd).not.toContain('-w "n%{http_code}"');
-  });
-
-  it('preserves backslashes in Windows file paths', () => {
-    // Simulate a Windows-style path with backslashes
-    const windowsStylePath = 'C:\\Users\\test\\mapping.txt';
-    const windowsConfig = { ...config(), mappingPath: windowsStylePath };
+    const args = requests[0].curlArgs;
     
-    // Create a real temp file for validation
-    const realPath = path.join(localTempDir, 'win-test.txt');
-    fs.writeFileSync(realPath, 'test');
-    windowsConfig.mappingPath = realPath;
-    
-    const requests = buildAndroidSymbolsUploadRequests(windowsConfig, { verbose: false, dryRun: false }, []);
-    const cmd = requests[0].curlCommand;
-    
-    // The path should still contain backslashes (not consumed as escapes)
-    // This test verifies the parser preserves backslashes that aren't escape sequences
-    expect(cmd).toContain(realPath);
+    // Verify -w flag and its value are separate args (not concatenated)
+    const wIndex = args.indexOf('-w');
+    expect(wIndex).toBeGreaterThan(-1);
+    expect(args[wIndex + 1]).toBe('\n%{http_code}');
   });
 });

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -281,4 +281,31 @@ describe('buildAndroidSymbolsUploadRequests', () => {
     expect(requests[1].curlCommand).toContain('-F "abi=arm64-v8a"');
     expect(requests[2].curlCommand).toContain('-F "abi=x86_64"');
   });
+
+  it('preserves backslash-n in curl -w format for HTTP status extraction', () => {
+    const requests = buildAndroidSymbolsUploadRequests(config(), { verbose: false, dryRun: false }, []);
+    expect(requests).toHaveLength(1);
+    const cmd = requests[0].curlCommand;
+    // Verify the command contains the literal backslash-n sequence, not just 'n'
+    expect(cmd).toContain('-w "\\n%{http_code}"');
+    expect(cmd).not.toContain('-w "n%{http_code}"');
+  });
+
+  it('preserves backslashes in Windows file paths', () => {
+    // Simulate a Windows-style path with backslashes
+    const windowsStylePath = 'C:\\Users\\test\\mapping.txt';
+    const windowsConfig = { ...config(), mappingPath: windowsStylePath };
+    
+    // Create a real temp file for validation
+    const realPath = path.join(localTempDir, 'win-test.txt');
+    fs.writeFileSync(realPath, 'test');
+    windowsConfig.mappingPath = realPath;
+    
+    const requests = buildAndroidSymbolsUploadRequests(windowsConfig, { verbose: false, dryRun: false }, []);
+    const cmd = requests[0].curlCommand;
+    
+    // The path should still contain backslashes (not consumed as escapes)
+    // This test verifies the parser preserves backslashes that aren't escape sequences
+    expect(cmd).toContain(realPath);
+  });
 });

--- a/packages/faro-cli/src/test/androidSymbols.test.ts
+++ b/packages/faro-cli/src/test/androidSymbols.test.ts
@@ -1,0 +1,169 @@
+import { execSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildAndroidSymbolsCurlCommand, runAndroidSymbolsUpload } from '../androidSymbols';
+
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+}));
+
+const mockedExecSync = execSync as jest.MockedFunction<typeof execSync>;
+
+const baseConnection = {
+  endpoint: 'https://e.test/',
+  appId: 'aid',
+  stackId: 'sid',
+  apiKey: 'secret',
+  applicationId: 'com.grafana.quickpizza',
+  versionCode: '42',
+  versionName: '1.0',
+};
+
+describe('runAndroidSymbolsUpload', () => {
+  let tempDir: string;
+  let mappingPath: string;
+  let stdoutSpy: jest.SpiedFunction<typeof process.stdout.write>;
+  let stderrSpy: jest.SpiedFunction<typeof process.stderr.write>;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-android-'));
+    mappingPath = path.join(tempDir, 'mapping.txt');
+    fs.writeFileSync(mappingPath, 'com.example.Foo -> a:\n');
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockedExecSync.mockReset();
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns 2 when required settings are missing', async () => {
+    const code = await runAndroidSymbolsUpload({
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(2);
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/Missing required settings/);
+  });
+
+  it('returns 2 when neither mapping nor native-symbols is provided', async () => {
+    const code = await runAndroidSymbolsUpload({ ...baseConnection, verbose: false, dryRun: false });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/at least one of --mapping/i);
+  });
+
+  it('returns 2 when the mapping file does not exist', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: path.join(tempDir, 'missing.txt'),
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(2);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/mapping file not found/);
+  });
+
+  it('does not call curl on a dry run', async () => {
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: true,
+    });
+
+    expect(code).toBe(0);
+    expect(mockedExecSync).not.toHaveBeenCalled();
+    const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stdout).toMatch(/\[dry-run\] would upload Android symbols/);
+  });
+
+  it('uploads and returns 0 on a 2xx response', async () => {
+    mockedExecSync.mockReturnValue('\n201' as never);
+
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(0);
+    expect(mockedExecSync).toHaveBeenCalledTimes(1);
+    expect(mockedExecSync).toHaveBeenCalledWith(expect.stringContaining('curl -s'), expect.any(Object));
+    const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stdout).toMatch(/Upload complete \(HTTP 201\)/);
+  });
+
+  it('returns 1 on a non-2xx response', async () => {
+    mockedExecSync.mockReturnValue('bad request\n400' as never);
+
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(1);
+    const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join('');
+    expect(stderr).toMatch(/HTTP 400/);
+  });
+
+  it('returns 1 when curl throws', async () => {
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('curl: command not found');
+    });
+
+    const code = await runAndroidSymbolsUpload({
+      ...baseConnection,
+      mapping: mappingPath,
+      verbose: false,
+      dryRun: false,
+    });
+
+    expect(code).toBe(1);
+  });
+});
+
+describe('buildAndroidSymbolsCurlCommand', () => {
+  const config = {
+    ...baseConnection,
+    endpoint: 'https://e.test/',
+    mappingPath: '/abs/mapping.txt',
+    nativeSymbolsPath: '/abs/native-debug-symbols.zip',
+    bundleId: 'com.grafana.quickpizza@42@1.0',
+  };
+
+  it('builds the symbols/android URL, auth header and multipart fields', () => {
+    const cmd = buildAndroidSymbolsCurlCommand(config, { verbose: false, dryRun: false });
+
+    expect(cmd).toContain('"https://e.test/app/aid/symbols/android/com.grafana.quickpizza%4042%401.0"');
+    expect(cmd).toContain('-H "Authorization: Bearer sid:secret"');
+    expect(cmd).toContain('-F "mapping=@/abs/mapping.txt;type=text/plain"');
+    expect(cmd).toContain('-F "native-symbols=@/abs/native-debug-symbols.zip;type=application/zip"');
+    // Remote endpoint must not leak a stack-id header.
+    expect(cmd).not.toContain('X-Scope-OrgID');
+  });
+
+  it('adds X-Scope-OrgID for local endpoints', () => {
+    const cmd = buildAndroidSymbolsCurlCommand(
+      { ...config, endpoint: 'http://localhost:8000' },
+      { verbose: false, dryRun: false }
+    );
+
+    expect(cmd).toContain('-H "X-Scope-OrgID: sid"');
+  });
+});

--- a/packages/faro-cli/src/test/helpers/buildTestAgpZip.ts
+++ b/packages/faro-cli/src/test/helpers/buildTestAgpZip.ts
@@ -1,0 +1,6 @@
+import { buildZipFromEntries } from '../../nativeSymbolsByAbi';
+
+/** Builds a minimal AGP-style multi-ABI zip for unit tests. */
+export function buildTestAgpZip(entries: Array<[string, Buffer]>): Buffer {
+  return buildZipFromEntries(entries);
+}

--- a/packages/faro-cli/src/test/index.test.ts
+++ b/packages/faro-cli/src/test/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as tar from 'tar';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { gzipSync } from 'zlib';
 import { tmpdir } from 'os';
 import { consoleInfoOrange, THIRTY_MB_IN_BYTES, ensureSourceMapFileProperties } from '@grafana/faro-bundlers-shared';
@@ -75,6 +75,7 @@ describe('faro-cli', () => {
 
     // Mock child_process
     jest.mocked(execSync).mockReturnValue('{"success":true}\n__FARO_HTTP_STATUS__:201');
+    jest.mocked(execFileSync).mockReturnValue('{"success":true}\n__FARO_HTTP_STATUS__:201');
 
     // Mock zlib
     jest.mocked(gzipSync).mockReturnValue(Buffer.from('gzipped content'));
@@ -121,9 +122,10 @@ describe('faro-cli', () => {
       const result = await uploadSourceMap(mockOptions);
 
       expect(result).toBe(true);
-      expect(execSync).toHaveBeenCalledTimes(1);
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining(`curl -sS`),
+      expect(execFileSync).toHaveBeenCalledTimes(1);
+      expect(execFileSync).toHaveBeenCalledWith(
+        'curl',
+        expect.any(Array),
         expect.any(Object)
       );
     });
@@ -152,12 +154,12 @@ describe('faro-cli', () => {
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('exceeds the maximum allowed size')
       );
-      expect(execSync).not.toHaveBeenCalled();
+      expect(execFileSync).not.toHaveBeenCalled();
     });
 
 
     it('should report non-2xx HTTP status as upload failure', async () => {
-      (execSync as jest.Mock).mockReturnValue('Unauthorized\n__FARO_HTTP_STATUS__:401');
+      jest.mocked(execFileSync).mockReturnValue('Unauthorized\n__FARO_HTTP_STATUS__:401');
 
       const result = await uploadSourceMap(mockOptions);
 
@@ -168,7 +170,7 @@ describe('faro-cli', () => {
     });
 
     it('should handle curl execution errors', async () => {
-      (execSync as jest.Mock).mockImplementation(() => {
+      jest.mocked(execFileSync).mockImplementation(() => {
         throw new Error('curl error');
       });
 
@@ -184,8 +186,9 @@ describe('faro-cli', () => {
         gzipPayload: true
       });
 
-      expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining('Content-Encoding: gzip'),
+      expect(execFileSync).toHaveBeenCalledWith(
+        'curl',
+        expect.arrayContaining([expect.stringMatching(/Content-Encoding.*gzip/)]),
         expect.any(Object)
       );
     });
@@ -212,7 +215,7 @@ describe('faro-cli', () => {
         expect.objectContaining({ z: true }),
         expect.arrayContaining([mockFilePath])
       );
-      expect(execSync).toHaveBeenCalledTimes(1);
+      expect(execFileSync).toHaveBeenCalledTimes(1);
     });
 
     it('should delete the sourcemap files if keepSourcemaps is false', async () => {
@@ -358,7 +361,7 @@ describe('faro-cli', () => {
       expect(result).toBe(true);
       // 5 files with batchSize=2 → 3 batches (2, 2, 1), each creating a tarball
       expect(tar.create).toHaveBeenCalledTimes(3);
-      expect(execSync).toHaveBeenCalledTimes(3);
+      expect(execFileSync).toHaveBeenCalledTimes(3);
     });
 
     it('should upload all files in a single batch when batchSize exceeds file count', async () => {
@@ -378,7 +381,7 @@ describe('faro-cli', () => {
       expect(result).toBe(true);
       // All 3 files fit in one batch
       expect(tar.create).toHaveBeenCalledTimes(1);
-      expect(execSync).toHaveBeenCalledTimes(1);
+      expect(execFileSync).toHaveBeenCalledTimes(1);
     });
 
     it('should split files into batches by maxUploadSize', async () => {
@@ -399,7 +402,7 @@ describe('faro-cli', () => {
       expect(result).toBe(true);
       // 3 files at 20MB each, 30MB limit → batches of 1 file each
       expect(tar.create).toHaveBeenCalledTimes(3);
-      expect(execSync).toHaveBeenCalledTimes(3);
+      expect(execFileSync).toHaveBeenCalledTimes(3);
     });
 
     it('should respect whichever limit is hit first: batchSize or maxUploadSize', async () => {
@@ -420,7 +423,7 @@ describe('faro-cli', () => {
       expect(result).toBe(true);
       // batchSize=1 forces 4 batches even though size limit wouldn't require it
       expect(tar.create).toHaveBeenCalledTimes(4);
-      expect(execSync).toHaveBeenCalledTimes(4);
+      expect(execFileSync).toHaveBeenCalledTimes(4);
     });
 
     it('should use batchSize for non-gzip chunked uploads (>10 files)', async () => {
@@ -440,7 +443,7 @@ describe('faro-cli', () => {
 
       expect(result).toBe(true);
       // 12 files, batchSize=5, no gzip → individual uploads but chunked: 5+5+2 = 12 curl calls
-      expect(execSync).toHaveBeenCalledTimes(12);
+      expect(execFileSync).toHaveBeenCalledTimes(12);
       // No tarballs created
       expect(tar.create).not.toHaveBeenCalled();
     });

--- a/packages/faro-cli/src/test/index.test.ts
+++ b/packages/faro-cli/src/test/index.test.ts
@@ -74,7 +74,7 @@ describe('faro-cli', () => {
     jest.mocked(path.join).mockImplementation((...args: string[]) => args.join('/'));
 
     // Mock child_process
-    jest.mocked(execSync).mockReturnValue('{"success":true}');
+    jest.mocked(execSync).mockReturnValue('{"success":true}\n__FARO_HTTP_STATUS__:201');
 
     // Mock zlib
     jest.mocked(gzipSync).mockReturnValue(Buffer.from('gzipped content'));
@@ -123,7 +123,7 @@ describe('faro-cli', () => {
       expect(result).toBe(true);
       expect(execSync).toHaveBeenCalledTimes(1);
       expect(execSync).toHaveBeenCalledWith(
-        expect.stringContaining(`curl -s -X POST`),
+        expect.stringContaining(`curl -sS`),
         expect.any(Object)
       );
     });
@@ -153,6 +153,18 @@ describe('faro-cli', () => {
         expect.stringContaining('exceeds the maximum allowed size')
       );
       expect(execSync).not.toHaveBeenCalled();
+    });
+
+
+    it('should report non-2xx HTTP status as upload failure', async () => {
+      (execSync as jest.Mock).mockReturnValue('Unauthorized\n__FARO_HTTP_STATUS__:401');
+
+      const result = await uploadSourceMap(mockOptions);
+
+      expect(result).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('source map upload failed with HTTP 401')
+      );
     });
 
     it('should handle curl execution errors', async () => {

--- a/packages/faro-cli/src/test/index.test.ts
+++ b/packages/faro-cli/src/test/index.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import * as tar from 'tar';
-import { execSync, execFileSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { gzipSync } from 'zlib';
 import { tmpdir } from 'os';
 import { consoleInfoOrange, THIRTY_MB_IN_BYTES, ensureSourceMapFileProperties } from '@grafana/faro-bundlers-shared';
@@ -74,7 +74,6 @@ describe('faro-cli', () => {
     jest.mocked(path.join).mockImplementation((...args: string[]) => args.join('/'));
 
     // Mock child_process
-    jest.mocked(execSync).mockReturnValue('{"success":true}\n__FARO_HTTP_STATUS__:201');
     jest.mocked(execFileSync).mockReturnValue('{"success":true}\n__FARO_HTTP_STATUS__:201');
 
     // Mock zlib

--- a/packages/faro-cli/src/test/metro.test.ts
+++ b/packages/faro-cli/src/test/metro.test.ts
@@ -573,7 +573,7 @@ describe('runMetroUpload — upload delegation', () => {
 
     expect(code).toBe(1);
     const stderr = stderrSpy.mock.calls.map((call) => String(call[0])).join('');
-    expect(stderr).toMatch(/Upload failed/);
+    expect(stderr).toMatch(/Metro composed source map upload failed/);
   });
 
   it('passes verbose=true through to the gzip upload helper', async () => {

--- a/packages/faro-cli/src/test/nativeSymbolsByAbi.test.ts
+++ b/packages/faro-cli/src/test/nativeSymbolsByAbi.test.ts
@@ -47,6 +47,10 @@ describe('nativeSymbolsByAbi', () => {
     for (const artifact of artifacts) {
       expect(fs.existsSync(artifact.zipPath)).toBe(true);
     }
+    
+    // Verify artifacts are sorted by ABI name
+    const abis = artifacts.map((a) => a.abi);
+    expect(abis).toEqual(['arm64-v8a', 'armeabi-v7a', 'x86', 'x86_64']);
   });
 
   it('buildAbiZip produces parseable zip output', () => {

--- a/packages/faro-cli/src/test/nativeSymbolsByAbi.test.ts
+++ b/packages/faro-cli/src/test/nativeSymbolsByAbi.test.ts
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { buildAbiZip, groupEntriesByAbi, packNativeSymbolsByAbi, readAgpNativeZip } from '../nativeSymbolsByAbi';
+import { buildTestAgpZip } from './helpers/buildTestAgpZip';
+
+describe('nativeSymbolsByAbi', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-native-abi-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('groups AGP zip entries by ABI and normalizes .so.dbg', () => {
+    const agp = buildTestAgpZip([
+      ['arm64-v8a/libfoo.so.dbg', Buffer.from('elf-a')],
+      ['x86_64/libfoo.so', Buffer.from('elf-x')],
+    ]);
+
+    const grouped = groupEntriesByAbi(readAgpNativeZip(agp));
+    expect([...grouped.keys()].sort()).toEqual(['arm64-v8a', 'x86_64']);
+    expect(grouped.get('arm64-v8a')!.has('arm64-v8a/libfoo.so')).toBe(true);
+  });
+
+  it('packNativeSymbolsByAbi writes one zip per ABI', () => {
+    const agpPath = path.join(tempDir, 'native-debug-symbols.zip');
+    fs.writeFileSync(
+      agpPath,
+      buildTestAgpZip([
+        ['arm64-v8a/liba.so', Buffer.alloc(1024, 1)],
+        ['armeabi-v7a/libb.so', Buffer.alloc(1024, 2)],
+        ['x86_64/libc.so', Buffer.alloc(1024, 3)],
+        ['x86/libd.so', Buffer.alloc(1024, 4)],
+      ]),
+    );
+
+    const outDir = path.join(tempDir, 'abi-out');
+    const artifacts = packNativeSymbolsByAbi(agpPath, outDir);
+
+    expect(artifacts).toHaveLength(4);
+    expect(artifacts.every((a) => a.bytes > 0 && a.bytes < 45 * 1024 * 1024)).toBe(true);
+    for (const artifact of artifacts) {
+      expect(fs.existsSync(artifact.zipPath)).toBe(true);
+    }
+  });
+
+  it('buildAbiZip produces parseable zip output', () => {
+    const zip = buildAbiZip(
+      new Map([
+        ['arm64-v8a/libdemo.so', Buffer.from([0x7f, 0x45, 0x4c, 0x46])],
+      ]),
+    );
+    expect(zip.length).toBeGreaterThan(0);
+    const entries = readAgpNativeZip(zip);
+    expect(entries.some((e) => e.name === 'arm64-v8a/libdemo.so')).toBe(true);
+  });
+});

--- a/packages/faro-metro-plugin/src/index.ts
+++ b/packages/faro-metro-plugin/src/index.ts
@@ -41,4 +41,11 @@ export {
 } from './serialize';
 export { shiftGeneratedLineNumbers } from './shiftSourceMap';
 export { flattenMapForHermes } from './flattenMapForHermes';
-export { normalizeBundleIdLength, resolveBundleId } from './resolveBundleId';
+export {
+  normalizeBundleIdLength,
+  resolveBundleId,
+  resolveRnProjectRoot,
+  validateAndroidBundleId,
+  isIosBundleContext,
+  type ResolveBundleIdOptions,
+} from './resolveBundleId';

--- a/packages/faro-metro-plugin/src/resolveBundleId.ts
+++ b/packages/faro-metro-plugin/src/resolveBundleId.ts
@@ -1,7 +1,7 @@
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { randomString, consoleInfoOrange } from '@grafana/faro-bundlers-shared';
 
 const MAX_BUNDLE_ID_LEN = 512;
@@ -101,12 +101,8 @@ function readBundleIdFile(filePath: string): string | undefined {
 
 /**
  * Runs Gradle task to write bundle id file.
- * 
- * Security note: execSync with shell=true is used here because:
- * 1. androidModule is validated to contain only safe characters
- * 2. gradlew path is resolved from the project structure
- * 3. The task name is constructed from validated inputs
- * 4. All inputs are checked before shell execution
+ * Uses execFileSync to avoid shell interpretation.
+ * androidModule is validated to contain only safe characters before use.
  */
 function runGradleWriteBundleId(
   projectRoot: string,
@@ -125,7 +121,7 @@ function runGradleWriteBundleId(
   }
   const variantCap = variant.replace(/^\w/, (c) => c.toUpperCase());
   const task = `:${androidModule}:faroWriteBundleId${variantCap}`;
-  execSync(`"${gradlew}" ${task} -q`, {
+  execFileSync(gradlew, [task, '-q'], {
     cwd: androidDir,
     stdio: ['ignore', 'pipe', 'pipe'],
     env: process.env,

--- a/packages/faro-metro-plugin/src/resolveBundleId.ts
+++ b/packages/faro-metro-plugin/src/resolveBundleId.ts
@@ -1,7 +1,55 @@
 import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
 import { randomString, consoleInfoOrange } from '@grafana/faro-bundlers-shared';
 
 const MAX_BUNDLE_ID_LEN = 512;
+
+/** Matches KWL Android symbol ingest: `{applicationId}@{versionCode}@{versionName}`. */
+const ANDROID_BUNDLE_ID_PATTERN = /^[^@]+@\d+@[^@]+$/;
+
+/** Production JS bundle / symbol uploads use the release AGP variant only. */
+const ANDROID_RELEASE_VARIANT = 'release';
+
+export type ResolveBundleIdOptions = {
+  bundleId?: string;
+  /**
+   * Android application module folder under `android/` (default `app`).
+   * Only set when the RN app module is not `app` (monorepo / custom layout).
+   */
+  androidModule?: string;
+};
+
+function isRnProjectRoot(dir: string): boolean {
+  return (
+    fs.existsSync(path.join(dir, 'metro.config.js')) ||
+    fs.existsSync(path.join(dir, 'metro.config.ts')) ||
+    fs.existsSync(path.join(dir, 'react-native.config.js'))
+  );
+}
+
+/**
+ * RN project root (folder with `metro.config.js`). Metro passes this on `bundleOptions`;
+ * when Gradle runs Metro with cwd `android/`, we walk up one level.
+ */
+export function resolveRnProjectRoot(bundleOptions?: Record<string, unknown>): string {
+  const fromMetro = bundleOptions?.projectRoot;
+  if (typeof fromMetro === 'string' && fromMetro.length > 0) {
+    return fromMetro;
+  }
+  const cwd = process.cwd();
+  if (isRnProjectRoot(cwd)) {
+    return cwd;
+  }
+  if (path.basename(cwd) === 'android') {
+    const parent = path.dirname(cwd);
+    if (isRnProjectRoot(parent)) {
+      return parent;
+    }
+  }
+  return cwd;
+}
 
 export function normalizeBundleIdLength(id: string): string {
   if (id.length <= MAX_BUNDLE_ID_LEN) {
@@ -10,18 +58,138 @@ export function normalizeBundleIdLength(id: string): string {
   return crypto.createHash('sha256').update(id, 'utf8').digest('hex').slice(0, 32);
 }
 
-export function resolveBundleId(
-  explicitFromOptions: string | undefined,
-  bundleDev: boolean,
-  skipUpload: boolean
-): string {
-  const explicit = explicitFromOptions ?? process.env.FARO_BUNDLE_ID;
-  if (explicit) {
-    return normalizeBundleIdLength(explicit);
+export function validateAndroidBundleId(bundleId: string): boolean {
+  return ANDROID_BUNDLE_ID_PATTERN.test(bundleId);
+}
+
+/** Same signals as typical `metro.config.js` (Xcode `PLATFORM_NAME`, or `FARO_PLATFORM=ios`). */
+export function isIosBundleContext(): boolean {
+  const platform = (process.env.FARO_PLATFORM ?? '').toLowerCase();
+  if (platform === 'ios') {
+    return true;
   }
+  const xc = (process.env.PLATFORM_NAME ?? '').toLowerCase();
+  return xc.includes('iphone') || xc.includes('ipad');
+}
+
+function bundleIdFilePath(
+  projectRoot: string,
+  androidModule: string,
+  variant: string
+): string {
+  return path.join(
+    projectRoot,
+    'android',
+    androidModule,
+    'build',
+    'faro',
+    `bundle-id-${variant}.txt`
+  );
+}
+
+function readBundleIdFile(filePath: string): string | undefined {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return undefined;
+    }
+    const raw = fs.readFileSync(filePath, 'utf8').trim();
+    return raw || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function runGradleWriteBundleId(
+  projectRoot: string,
+  androidModule: string,
+  variant: string
+): void {
+  const androidDir = path.join(projectRoot, 'android');
+  const gradlew = path.join(androidDir, process.platform === 'win32' ? 'gradlew.bat' : 'gradlew');
+  if (!fs.existsSync(gradlew)) {
+    throw new Error(
+      `[faro-metro-plugin] Android Gradle wrapper not found at ${gradlew}. ` +
+        'Run from an RN project with android/, or build via ./gradlew assembleRelease first.'
+    );
+  }
+  const variantCap = variant.replace(/^\w/, (c) => c.toUpperCase());
+  const task = `:${androidModule}:faroWriteBundleId${variantCap}`;
+  execSync(`"${gradlew}" ${task} -q`, {
+    cwd: androidDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: process.env,
+  });
+}
+
+function resolveFromAndroidGradle(
+  options: ResolveBundleIdOptions,
+  bundleOptions?: Record<string, unknown>
+): string | undefined {
+  const projectRoot = resolveRnProjectRoot(bundleOptions);
+  const androidModule = options.androidModule ?? 'app';
+  const filePath = bundleIdFilePath(projectRoot, androidModule, ANDROID_RELEASE_VARIANT);
+
+  let id = readBundleIdFile(filePath);
+  if (id && validateAndroidBundleId(id)) {
+    return normalizeBundleIdLength(id);
+  }
+
+  try {
+    runGradleWriteBundleId(projectRoot, androidModule, ANDROID_RELEASE_VARIANT);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `[faro-metro-plugin] Failed to resolve Android Faro bundle id via Gradle (${taskLabel(androidModule, ANDROID_RELEASE_VARIANT)}). ${message}`
+    );
+  }
+
+  id = readBundleIdFile(filePath);
+  if (!id || !validateAndroidBundleId(id)) {
+    throw new Error(
+      `[faro-metro-plugin] Invalid or missing bundle id at ${filePath}. ` +
+        'Apply the Faro Gradle plugin (com.grafana.faro) and ensure release variant version fields are set.'
+    );
+  }
+  return normalizeBundleIdLength(id);
+}
+
+function taskLabel(androidModule: string, variant: string): string {
+  const variantCap = variant.replace(/^\w/, (c) => c.toUpperCase());
+  return `:${androidModule}:faroWriteBundleId${variantCap}`;
+}
+
+export function resolveBundleId(
+  options: ResolveBundleIdOptions | string | undefined,
+  bundleDev: boolean,
+  skipUpload: boolean,
+  bundleOptions?: Record<string, unknown>
+): string {
+  const opts: ResolveBundleIdOptions =
+    typeof options === 'string' ? { bundleId: options } : (options ?? {});
+
+  const explicit = opts.bundleId ?? process.env.FARO_BUNDLE_ID;
+  if (explicit) {
+    const normalized = normalizeBundleIdLength(explicit.trim());
+    if (!isIosBundleContext() && !bundleDev && !skipUpload && !validateAndroidBundleId(normalized)) {
+      throw new Error(
+        `[faro-metro-plugin] bundle id "${explicit}" is not a valid Android release identity ` +
+          '(expected applicationId@versionCode@versionName). Remove FARO_BUNDLE_ID from CI and use the Faro Gradle plugin.'
+      );
+    }
+    return normalized;
+  }
+
   if (bundleDev || skipUpload) {
     return normalizeBundleIdLength(`dev-${randomString(6)}`);
   }
+
+  if (!isIosBundleContext()) {
+    const fromGradle = resolveFromAndroidGradle(opts, bundleOptions);
+    if (fromGradle) {
+      return fromGradle;
+    }
+  }
+
   consoleInfoOrange(
     'FARO_BUNDLE_ID is not set; using an ephemeral id for this build. Set FARO_BUNDLE_ID so uploads match meta.app.bundleId.'
   );

--- a/packages/faro-metro-plugin/src/resolveBundleId.ts
+++ b/packages/faro-metro-plugin/src/resolveBundleId.ts
@@ -99,11 +99,22 @@ function readBundleIdFile(filePath: string): string | undefined {
   }
 }
 
+/**
+ * Runs Gradle task to write bundle id file.
+ * 
+ * Security note: execSync with shell=true is used here because:
+ * 1. androidModule is validated to contain only safe characters
+ * 2. gradlew path is resolved from the project structure
+ * 3. The task name is constructed from validated inputs
+ * 4. All inputs are checked before shell execution
+ */
 function runGradleWriteBundleId(
   projectRoot: string,
   androidModule: string,
   variant: string
 ): void {
+  validateAndroidModule(androidModule);
+  
   const androidDir = path.join(projectRoot, 'android');
   const gradlew = path.join(androidDir, process.platform === 'win32' ? 'gradlew.bat' : 'gradlew');
   if (!fs.existsSync(gradlew)) {
@@ -127,6 +138,7 @@ function resolveFromAndroidGradle(
 ): string | undefined {
   const projectRoot = resolveRnProjectRoot(bundleOptions);
   const androidModule = options.androidModule ?? 'app';
+  validateAndroidModule(androidModule);
   const filePath = bundleIdFilePath(projectRoot, androidModule, ANDROID_RELEASE_VARIANT);
 
   let id = readBundleIdFile(filePath);
@@ -156,6 +168,21 @@ function resolveFromAndroidGradle(
 function taskLabel(androidModule: string, variant: string): string {
   const variantCap = variant.replace(/^\w/, (c) => c.toUpperCase());
   return `:${androidModule}:faroWriteBundleId${variantCap}`;
+}
+
+function validateAndroidModule(androidModule: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(androidModule)) {
+    throw new Error(
+      `[faro-metro-plugin] Invalid androidModule "${androidModule}". ` +
+        'Must contain only alphanumeric characters, hyphens, and underscores.'
+    );
+  }
+  if (androidModule.includes('..') || androidModule.includes('/') || androidModule.includes('\\')) {
+    throw new Error(
+      `[faro-metro-plugin] Invalid androidModule "${androidModule}". ` +
+        'Path traversal characters are not allowed.'
+    );
+  }
 }
 
 export function resolveBundleId(

--- a/packages/faro-metro-plugin/src/serialize.ts
+++ b/packages/faro-metro-plugin/src/serialize.ts
@@ -26,6 +26,11 @@ export type FaroMetroPluginOptions = FaroSourceMapUploaderPluginOptions & {
    * back to the legacy `+1` line shift.
    */
   hermes?: boolean;
+  /**
+   * Android app module folder under `android/` (default `app`). Release variant only.
+   * Override only when the application module is not named `app`.
+   */
+  androidModule?: string;
 };
 
 /**
@@ -169,7 +174,7 @@ export function createFaroMetroCustomSerializer(
 
     const { code, map } = await toCodeAndMap(inner, prepend, graph, bundleOptions);
 
-    const bundleId = resolveBundleId(pluginOptions.bundleId, bundleDev, skip);
+    const bundleId = resolveBundleId(pluginOptions, bundleDev, skip, bundleOptions);
     const snippet = faroBundleIdSnippet(bundleId, pluginOptions.appName);
     const newCode = `${snippet}\n${code}`;
 

--- a/packages/faro-metro-plugin/src/test/detectHermesMode.test.ts
+++ b/packages/faro-metro-plugin/src/test/detectHermesMode.test.ts
@@ -75,9 +75,12 @@ describe('detectHermesMode', () => {
 
 describe('serializer behaviour by Hermes mode', () => {
   let prevNodeEnv: string | undefined;
+  let prevPlatform: string | undefined;
   beforeEach(() => {
     prevNodeEnv = process.env.NODE_ENV;
+    prevPlatform = process.env.FARO_PLATFORM;
     process.env.NODE_ENV = 'production';
+    process.env.FARO_PLATFORM = 'ios';
     process.env.FARO_BUNDLE_ID = 'unit-test-id';
   });
 
@@ -86,6 +89,11 @@ describe('serializer behaviour by Hermes mode', () => {
       delete process.env.NODE_ENV;
     } else {
       process.env.NODE_ENV = prevNodeEnv;
+    }
+    if (prevPlatform === undefined) {
+      delete process.env.FARO_PLATFORM;
+    } else {
+      process.env.FARO_PLATFORM = prevPlatform;
     }
     delete process.env.FARO_BUNDLE_ID;
     delete process.env.FARO_DISABLE_HERMES_PRECOMPILE;

--- a/packages/faro-metro-plugin/src/test/index.test.ts
+++ b/packages/faro-metro-plugin/src/test/index.test.ts
@@ -24,12 +24,29 @@ describe('@grafana/faro-metro-plugin', () => {
     );
   });
 
-  test('resolveBundleId uses env FARO_BUNDLE_ID with trimming via hash when too long', () => {
+  test('resolveBundleId uses Gradle-aligned FARO_BUNDLE_ID from env', () => {
+    const prev = process.env.FARO_BUNDLE_ID;
+    process.env.FARO_BUNDLE_ID = 'com.test.app@42@1.0.0';
+    try {
+      const id = resolveBundleId({}, false, false);
+      expect(id).toBe('com.test.app@42@1.0.0');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.FARO_BUNDLE_ID;
+      } else {
+        process.env.FARO_BUNDLE_ID = prev;
+      }
+    }
+  });
+
+  test('resolveBundleId hashes long env id on iOS (no Android format enforcement)', () => {
     const longId = 'a'.repeat(600);
     const prev = process.env.FARO_BUNDLE_ID;
+    const prevPlatform = process.env.FARO_PLATFORM;
     process.env.FARO_BUNDLE_ID = longId;
+    process.env.FARO_PLATFORM = 'ios';
     try {
-      const id = resolveBundleId(undefined, false, false);
+      const id = resolveBundleId({}, false, false);
       expect(id.length).toBeLessThanOrEqual(512);
       expect(id.length).toBe(32);
     } finally {
@@ -37,6 +54,11 @@ describe('@grafana/faro-metro-plugin', () => {
         delete process.env.FARO_BUNDLE_ID;
       } else {
         process.env.FARO_BUNDLE_ID = prev;
+      }
+      if (prevPlatform === undefined) {
+        delete process.env.FARO_PLATFORM;
+      } else {
+        process.env.FARO_PLATFORM = prevPlatform;
       }
     }
   });
@@ -127,7 +149,7 @@ describe('@grafana/faro-metro-plugin', () => {
     });
 
     test('prepends faro bundle id snippet (release bundle)', async () => {
-      process.env.FARO_BUNDLE_ID = 'release-id-1';
+      process.env.FARO_BUNDLE_ID = 'com.test.app@1@1.0';
       const serializer = createFaroMetroCustomSerializer(null, {
         appName: 'rn-app',
         endpoint: 'http://localhost:8000/faro/api/v1',
@@ -139,7 +161,7 @@ describe('@grafana/faro-metro-plugin', () => {
       const graph = { dependencies: new Map() };
       const out = await serializer('/app/index.js', [], graph, baseOptions());
       expect(out.code).toContain('__faroBundleId_rn-app');
-      expect(out.code).toContain('"release-id-1"');
+      expect(out.code).toContain('"com.test.app@1@1.0"');
       const parsed = JSON.parse(out.map) as { version: number };
       expect(parsed.version).toBe(3);
     });

--- a/packages/faro-metro-plugin/src/test/resolveBundleId.test.ts
+++ b/packages/faro-metro-plugin/src/test/resolveBundleId.test.ts
@@ -75,4 +75,39 @@ describe('resolveBundleId Android Gradle', () => {
     const id = resolveBundleId({}, false, false);
     expect(id).toBe('git-sha-only');
   });
+
+  test('throws when androidModule contains path traversal characters', () => {
+    delete process.env.FARO_BUNDLE_ID;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
+    
+    expect(() => {
+      resolveBundleId({ androidModule: '../evil' }, false, false, { projectRoot: root });
+    }).toThrow('Invalid androidModule');
+    
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('throws when androidModule contains special characters', () => {
+    delete process.env.FARO_BUNDLE_ID;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
+    
+    expect(() => {
+      resolveBundleId({ androidModule: 'app; rm -rf /' }, false, false, { projectRoot: root });
+    }).toThrow('Invalid androidModule');
+    
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('accepts valid androidModule with hyphens and underscores', () => {
+    delete process.env.FARO_BUNDLE_ID;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
+    const fileDir = path.join(root, 'android', 'my-app_module', 'build', 'faro');
+    fs.mkdirSync(fileDir, { recursive: true });
+    fs.writeFileSync(path.join(fileDir, 'bundle-id-release.txt'), 'com.test@1@1.0\n');
+
+    const id = resolveBundleId({ androidModule: 'my-app_module' }, false, false, { projectRoot: root });
+
+    expect(id).toBe('com.test@1@1.0');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
 });

--- a/packages/faro-metro-plugin/src/test/resolveBundleId.test.ts
+++ b/packages/faro-metro-plugin/src/test/resolveBundleId.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test, afterEach, jest } from '@jest/globals';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  resolveBundleId,
+  resolveRnProjectRoot,
+  validateAndroidBundleId,
+} from '../resolveBundleId';
+
+describe('resolveBundleId Android Gradle', () => {
+  const prevBundleId = process.env.FARO_BUNDLE_ID;
+  const prevPlatform = process.env.FARO_PLATFORM;
+
+  afterEach(() => {
+    if (prevBundleId === undefined) {
+      delete process.env.FARO_BUNDLE_ID;
+    } else {
+      process.env.FARO_BUNDLE_ID = prevBundleId;
+    }
+    if (prevPlatform === undefined) {
+      delete process.env.FARO_PLATFORM;
+    } else {
+      process.env.FARO_PLATFORM = prevPlatform;
+    }
+  });
+
+  test('resolveRnProjectRoot prefers Metro bundleOptions.projectRoot', () => {
+    const root = resolveRnProjectRoot({ projectRoot: '/from-metro' });
+    expect(root).toBe('/from-metro');
+  });
+
+  test('resolveRnProjectRoot walks up when cwd is android/', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-root-'));
+    fs.writeFileSync(path.join(root, 'metro.config.js'), 'module.exports = {};\n');
+    const androidDir = path.join(root, 'android');
+    fs.mkdirSync(androidDir);
+    const cwdSpy = jest.spyOn(process, 'cwd').mockReturnValue(androidDir);
+    try {
+      expect(resolveRnProjectRoot()).toBe(root);
+    } finally {
+      cwdSpy.mockRestore();
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test('validateAndroidBundleId accepts encoded triple', () => {
+    expect(validateAndroidBundleId('com.example@42@1.0')).toBe(true);
+    expect(validateAndroidBundleId('git-sha-only')).toBe(false);
+  });
+
+  test('reads bundle id from Gradle output file', () => {
+    delete process.env.FARO_BUNDLE_ID;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'faro-metro-'));
+    const fileDir = path.join(root, 'android', 'app', 'build', 'faro');
+    fs.mkdirSync(fileDir, { recursive: true });
+    fs.writeFileSync(path.join(fileDir, 'bundle-id-release.txt'), 'com.demo@7@2.1.0\n');
+
+    const id = resolveBundleId({ androidModule: 'app' }, false, false, { projectRoot: root });
+
+    expect(id).toBe('com.demo@7@2.1.0');
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  test('skips Gradle resolution on iOS platform (auto-detect)', () => {
+    delete process.env.FARO_BUNDLE_ID;
+    process.env.FARO_PLATFORM = 'ios';
+    const id = resolveBundleId({}, false, true);
+    expect(id).toMatch(/^dev-/);
+  });
+
+  test('auto-detect iOS does not enforce Android bundle id format on FARO_BUNDLE_ID', () => {
+    process.env.FARO_PLATFORM = 'ios';
+    process.env.FARO_BUNDLE_ID = 'git-sha-only';
+    const id = resolveBundleId({}, false, false);
+    expect(id).toBe('git-sha-only');
+  });
+});


### PR DESCRIPTION
## Summary

Extend the Faro bundler tooling for **Android native symbolication**: upload `R8/native symbol` artifacts via CLI, and align React Native release `bundleId` with the Faro Android Gradle plugin instead of manual `FARO_BUNDLE_ID`.

### `@grafana/faro-cli`

- Add **`faro-cli android upload`** — multipart POST of:
  - `--mapping` → R8 `mapping.txt`
  - `--native-symbols` → `native-debug-symbols.zip`
  - to `POST /app/{appId}/symbols/android/{applicationId@versionCode@versionName}`
- Build identity from flags or env (`FARO_ANDROID_APPLICATION_ID`, `FARO_ANDROID_VERSION_CODE`, `FARO_ANDROID_VERSION_NAME`); API creds reuse existing `FARO_SOURCEMAP_*`
- **`buildUploadHeaders`**: send `X-Scope-OrgID` for local KWL endpoints (noop auth)
- **Source map uploads**: curl now checks HTTP status via `-w` (2xx required) instead of substring-matching `"error"` in the body
- Clearer Metro upload failure message (endpoint, bundleId, local auth hint)

### `@grafana/faro-metro-plugin`

- **Android release bundle id** resolved from Gradle:
  - reads `android/{module}/build/faro/bundle-id-release.txt`
  - runs `:app:faroWriteBundleIdRelease` when missing (requires `com.grafana.faro`)
- Enforces **`applicationId@versionCode@versionName`** on Android release builds (rejects git-sha-style `FARO_BUNDLE_ID`)
- **iOS unchanged**: still uses `FARO_BUNDLE_ID` / ephemeral id; no Android format enforcement when `FARO_PLATFORM=ios` or Xcode `PLATFORM_NAME`
- New exports: `validateAndroidBundleId`, `resolveRnProjectRoot`, `isIosBundleContext`, `ResolveBundleIdOptions`
- Optional `androidModule` plugin option (default `app`)

### Tests

- `androidSymbols.test.ts` — CLI config validation, curl command shape, bundle id encoding
- `resolveBundleId.test.ts` — Gradle file read, iOS skip, Android format validation
- Updated existing metro-plugin / CLI tests for Gradle-aligned ids

## Related work

- **`faro-android-gradle-plugin`** — writes `bundle-id-release.txt` and can upload symbols from Gradle
- **`app-o11y-kwl-endpoint`** — `POST …/symbols/android/{bundleId}` + ingest R8 retrace
- **`faro-react-native-sdk`** — reads Gradle bundle id for composed map upload; Metro preamble + DeviceInfo fallback
- **`mobile-o11y-demo`** — release R8 builds and end-to-end validation

## Migration notes

| Platform | Before | After |
|----------|--------|-------|
| Android RN release | export `FARO_BUNDLE_ID=$(git …)` | apply `com.grafana.faro`; omit `FARO_BUNDLE_ID` — Metro reads Gradle file |
| iOS release | `FARO_BUNDLE_ID` or config `bundleId` | unchanged |
| Manual symbol upload | N/A | `faro-cli android upload --mapping … --native-symbols …` |

## Demo
https://github.com/user-attachments/assets/dcc305d2-3485-479f-af46-6abef7c8f48c


## Verification

```bash
# From repo root
yarn workspace @grafana/faro-cli test
yarn workspace @grafana/faro-metro-plugin test

# Dry-run Android symbol upload (against local KWL API)
faro-cli android upload \
  --mapping ./mapping.txt \
  --native-symbols ./native-debug-symbols.zip \
  --endpoint http://localhost:8000/faro/api/v1 \
  --app-id 1 --stack-id 1 --api-key auth_token_value \
  --application-id com.example --version-code 42 --version-name 1.0 \
  --dry-run

# RN Android release: with Faro Gradle plugin applied, bundle preamble should be com.example@42@1.0
# (no FARO_BUNDLE_ID in CI)