### PR TITLE
fix(deps): patch CVE-2026-33750 in brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "minimatch": "^8.0.5",
     "axios": "1.16.0",
     "fast-uri": "3.1.2",
-    "ip-address": "10.2.0"
+    "ip-address": "10.2.0",
+    "nx/brace-expansion": "5.0.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4234,21 +4234,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.2":
-  version: 5.0.2
-  resolution: "brace-expansion@npm:5.0.2"
+"brace-expansion@npm:5.0.6":
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/18d382c0919c68f8bb56fbe4a9cb1181a0bf10e6786b5683e586493dfbb517bdcf972f4a3a8d560486627fd9c9c6ecef0a2b8fd454eb6082780307ffd5586251
+  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.1":
-  version: 2.1.0
-  resolution: "brace-expansion@npm:2.1.0"
+  version: 2.1.1
+  resolution: "brace-expansion@npm:2.1.1"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10/c77a7a64aabf94b8d5913955adb4f36957917565374461355bb4276830c027a313d981f32410cea9e38f52573e7eb776d02fe05091c3a79a061958d97e4d2b43
+  checksum: 10/4681c533dc4e6c77b3ad795b38683d297fd03c739a17bfb2a338529fa7dcf4540683a79dcd662905f4c5b0db7cfda18daafcd18dd1bbf7c3b076fe0c9c3487eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Fixes [CVE-2026-33750](https://nvd.nist.gov/vuln/detail/CVE-2026-33750) 

## Details

The resolution is scoped to `nx/brace-expansion` rather than a blanket override because `minimatch@8.0.7` also depends on `brace-expansion@^2.0.1` (resolved to `2.1.1`, which is already patched) and is incompatible with the 5.x CJS export structure.
