### PR TITLE
fix(ci): align Renovate npm cooldown with yarn 7-day age gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -41,6 +41,11 @@
       },
       "labels": ["security"],
       "prPriority": 10
+    },
+    {
+      "description": "Enforce a 7-day release-age cooldown on ALL npm depTypes to match yarn's npmMinimalAgeGate (.yarnrc.yml). Placed last so it overrides the injected Grafana org preset rule (grafana-renovate-config//presets/npm) which only waits 3 days for runtime dependencies (and skips the wait for @grafana/* packages). Without this, Renovate proposes versions younger than 7 days that yarn then quarantines (YN0016), producing un-mergeable PRs.",
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
## Why

Renovate bot PRs (#594, #595, #597, #598, #599, #600, #611) fail CI at `yarn install --immutable` with `YN0016 … quarantined` and stay open/un-mergeable.

Two release-age cooldowns are misaligned: yarn's `.yarnrc.yml` `npmMinimalAgeGate` is **7 days**, but the injected Grafana org Renovate preset waits only **3 days** for npm deps (and skips the wait for `@grafana/*`). A `packageRules` entry beats our top-level `minimumReleaseAge`, so Renovate proposes versions younger than 7 days that yarn then quarantines while regenerating the lockfile (`renovate/artifacts` failure → `package.json`/`yarn.lock` mismatch → CI can't install).

## What

Add an explicit `packageRule` (placed last so it overrides the injected preset) enforcing a 7-day cooldown across all npm depTypes, matching the yarn gate:

```json
{ "matchDatasources": ["npm"], "minimumReleaseAge": "7 days" }
```

Effective once merged to `main`; the stuck bot PRs go green on their next Renovate rebase.

## Links

- Same fix as grafana/faro-web-sdk#2133.
- Confirmed in Renovate logs: `YN0016: rollup@4.62.0 … quarantined`.

## Checklist

- [ ] Tests added — n/a (CI config only)
- [ ] Changelog updated — n/a
- [ ] Documentation updated — n/a