### PR TITLE
fix(security): resolve follow-redirects CVE-2026-40895

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "axios": "1.16.0",
     "fast-uri": "3.1.2",
     "ip-address": "10.2.0",
-    "nx/brace-expansion": "5.0.6"
+    "nx/brace-expansion": "5.0.6",
+    "nx/follow-redirects": "^1.16.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5564,16 +5564,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10/07372fd74b98c78cf4d417d68d41fdaa0be4dcacafffb9e67b1e3cf090bc4771515e65020651528faab238f10f9b9c0d9707d6c1574a6c0387c5de1042cde9ba
-  languageName: node
-  linkType: hard
-
 "follow-redirects@npm:^1.16.0":
   version: 1.16.0
   resolution: "follow-redirects@npm:1.16.0"


### PR DESCRIPTION
## Summary

Forces `follow-redirects` to the patched `1.16.0` across the dependency tree, resolving CVE-2026-40895 (GHSA-r4q5-vmmm-2653, custom auth headers leaked to cross-domain redirect targets).

`nx@22.7.1` (transitive via `lerna`) pulled the vulnerable `follow-redirects@1.15.11`. A `nx/follow-redirects` resolution override pins it to `^1.16.0`. The lockfile now contains no references to `1.15.11`.

## Changes

- `package.json`: add `"nx/follow-redirects": "^1.16.0"` resolution
- `yarn.lock`: regenerated; `follow-redirects@1.15.11` removed

## Notes

- This resolution targets a **dev dependency** (`nx`, via `lerna`), so the vulnerable package was never shipped in the published `packages/*`. We still need to fix it: our vulnerability scanner alerts on dev dependencies too, so they must be addressed as well.
- CVE-2026-33750 (brace-expansion) was already covered — only patched versions (`2.1.1`, `5.0.6`) resolve, the latter via the pre-existing `nx/brace-expansion` resolution.