### PR TITLE
chore(deps): lower release-age cooldown to 3 days

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,7 @@
   "separateMultipleMajor": true,
   "prHourlyLimit": 2,
   "prConcurrentLimit": 10,
-  "minimumReleaseAge": "7 days",
+  "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
   "packageRules": [
     {
@@ -43,9 +43,9 @@
       "prPriority": 10
     },
     {
-      "description": "Enforce a 7-day release-age cooldown on ALL npm depTypes to match yarn's npmMinimalAgeGate (.yarnrc.yml). Placed last so it overrides the injected Grafana org preset rule (grafana-renovate-config//presets/npm) which only waits 3 days for runtime dependencies (and skips the wait for @grafana/* packages). Without this, Renovate proposes versions younger than 7 days that yarn then quarantines (YN0016), producing un-mergeable PRs.",
+      "description": "Enforce a 3-day release-age cooldown on ALL npm depTypes (incl @grafana/*, which the org preset exempts) to match yarn's npmMinimalAgeGate (.yarnrc.yml). Placed last so it overrides the injected Grafana org preset rule (grafana-renovate-config//presets/npm). Without this, Renovate proposes versions younger than the gate that yarn then quarantines (YN0016), producing un-mergeable PRs.",
       "matchDatasources": ["npm"],
-      "minimumReleaseAge": "7 days"
+      "minimumReleaseAge": "3 days"
     }
   ]
 }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -7,7 +7,7 @@ enableImmutableInstalls: true
 
 nodeLinker: node-modules
 
-# Refuse to install npm package versions younger than 7 days as a defense
+# Refuse to install npm package versions younger than 3 days as a defense
 # against newly-published malicious packages (supply-chain attacks).
 # Value is a duration string; the underlying unit is minutes.
-npmMinimalAgeGate: 7d
+npmMinimalAgeGate: 3d


### PR DESCRIPTION
Lowers the npm release-age cooldown from 7 to 3 days to match the Grafana org Renovate default. Lowers yarn's `npmMinimalAgeGate` and Renovate's `minimumReleaseAge` together so they stay in sync (avoids YN0016 quarantine mismatches).

_PR description authored by Claude on Domas's behalf._