### PR TITLE
fix(security): pin form-data, tar, js-yaml; drop stale resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "resolutions": {
     "axios": "1.18.1",
     "fast-uri": "4.0.0",
-    "ip-address": "10.2.0",
-    "nx/brace-expansion": "5.0.6",
     "form-data": "4.0.6",
     "tar": "7.5.16",
     "js-yaml": "4.2.0"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "axios": "1.18.1",
     "fast-uri": "4.0.0",
     "ip-address": "10.2.0",
-    "nx/brace-expansion": "5.0.6"
+    "nx/brace-expansion": "5.0.6",
+    "form-data": "4.0.6",
+    "tar": "7.5.16",
+    "js-yaml": "4.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6491,7 +6491,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.2.0":
+"ip-address@npm:^10.1.1":
   version: 10.2.0
   resolution: "ip-address@npm:10.2.0"
   checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1

--- a/yarn.lock
+++ b/yarn.lock
@@ -4225,15 +4225,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7":
-  version: 1.0.10
-  resolution: "argparse@npm:1.0.10"
-  dependencies:
-    sprintf-js: "npm:~1.0.2"
-  checksum: 10/c6a621343a553ff3779390bb5ee9c2263d6643ebcd7843227bdde6cc7adbed796eb5540ca98db19e3fd7b4714e1faa51551f8849b268bb62df27ddb15cbcd91e
-  languageName: node
-  linkType: hard
-
 "array-ify@npm:^1.0.0":
   version: 1.0.0
   resolution: "array-ify@npm:1.0.0"
@@ -5548,16 +5539,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "esprima@npm:4.0.1"
-  bin:
-    esparse: ./bin/esparse.js
-    esvalidate: ./bin/esvalidate.js
-  checksum: 10/f1d3c622ad992421362294f7acf866aa9409fbad4eb2e8fa230bd33944ce371d32279667b242d8b8907ec2b6ad7353a717f3c0e60e748873a34a7905174bc0eb
-  languageName: node
-  linkType: hard
-
 "esrecurse@npm:^4.3.0":
   version: 4.3.0
   resolution: "esrecurse@npm:4.3.0"
@@ -5819,20 +5800,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:4.0.5":
-  version: 4.0.5
-  resolution: "form-data@npm:4.0.5"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.2"
-    mime-types: "npm:^2.1.12"
-  checksum: 10/52ecd6e927c8c4e215e68a7ad5e0f7c1031397439672fd9741654b4a94722c4182e74cc815b225dcb5be3f4180f36428f67c6dd39eaa98af0dcfdd26c00c19cd
-  languageName: node
-  linkType: hard
-
-"form-data@npm:^4.0.5":
+"form-data@npm:4.0.6":
   version: 4.0.6
   resolution: "form-data@npm:4.0.6"
   dependencies:
@@ -7293,30 +7261,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:4.1.1":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
-  dependencies:
-    argparse: "npm:^2.0.1"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/a52d0519f0f4ef5b4adc1cde466cb54c50d56e2b4a983b9d5c9c0f2f99462047007a6274d7e95617a21d3c91fde3ee6115536ed70991cd645ba8521058b78f77
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10/172e0b6007b0bf0fc8d2469c94424f7dd765c64a047d2b790831fecef2204a4054eabf4d911eb73ab8c9a3256ab8ba1ee8d655b789bf24bf059c772acc2075a1
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.0":
+"js-yaml@npm:4.2.0":
   version: 4.2.0
   resolution: "js-yaml@npm:4.2.0"
   dependencies:
@@ -8071,7 +8016,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:2.1.35, mime-types@npm:^2.1.12, mime-types@npm:^2.1.35":
+"mime-types@npm:2.1.35, mime-types@npm:^2.1.35":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -10001,13 +9946,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sprintf-js@npm:~1.0.2":
-  version: 1.0.3
-  resolution: "sprintf-js@npm:1.0.3"
-  checksum: 10/c34828732ab8509c2741e5fd1af6b767c3daf2c642f267788f933a65b1614943c282e74c4284f4fa749c264b18ee016a0d37a3e5b73aee446da46277d3a85daa
-  languageName: node
-  linkType: hard
-
 "ssri@npm:12.0.0, ssri@npm:^12.0.0":
   version: 12.0.0
   resolution: "ssri@npm:12.0.0"
@@ -10208,7 +10146,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:*, tar@npm:^7.1.0, tar@npm:^7.4.3, tar@npm:^7.5.4":
+"tar@npm:7.5.16":
   version: 7.5.16
   resolution: "tar@npm:7.5.16"
   dependencies:
@@ -10218,19 +10156,6 @@ __metadata:
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
   checksum: 10/fafa22efceb9f056bf29ddc47d9bd90bb82fe3ce57b8d1242fc45771251741964cebba69d4e14a24fd1643f3c7f68478e945a19def534703cf370c2d9dca2e09
-  languageName: node
-  linkType: hard
-
-"tar@npm:7.5.11":
-  version: 7.5.11
-  resolution: "tar@npm:7.5.11"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10/fb2e77ee858a73936c68e066f4a602d428d6f812e6da0cc1e14a41f99498e4f7fd3535e355fa15157240a5538aa416026cfa6306bb0d1d1c1abf314b1f878e9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes 3 transitive CVEs flagged by Vulnerability Observability and cleans up two now-dead resolutions.

### Security fixes (`fix(security)` commit)

Each vulnerable copy was held below its fix by an **exact-version pin in nx/lerna**, so natural re-resolution couldn't move it — each is forced via a root `resolutions` entry:

| Package | From | To | Severity | CVE | Strategy |
|---|---|---|---|---|---|
| form-data | 4.0.5 | 4.0.6 | HIGH | CVE-2026-12143 | resolution (in-major) |
| tar | 7.5.11 | 7.5.16 | MEDIUM | CVE-2026-53655 | resolution (in-major) |
| js-yaml | 3.14.2, 4.1.1 | 4.2.0 | MEDIUM | CVE-2026-53550 | resolution (major; jest coverage tooling only) |

- `form-data` 4.0.5 came from `nx` (exact pin); `tar` 7.5.11 from `lerna` (exact pin; direct deps were already on 7.5.16).
- `js-yaml` 3.14.2 comes only from jest coverage tooling (`babel-plugin-istanbul` → `@istanbuljs/load-nyc-config`, dev-only, never shipped); 4.1.1 from `lerna`. 4.2.0 is the only published fix — verified safe against the full test suite.

### Stale-resolution cleanup (`chore(deps)` commit)

Dropped `ip-address` and `nx/brace-expansion` resolutions — both are no-ops now (removing them leaves the resolved tree unchanged; parents have caught up since they were added). Verified by removing each and reinstalling.

### Already fixed on `main`

Most of the originally-flagged findings (undici, tmp, ws, yaml, follow-redirects) were already resolved by earlier merges and need no action here.

Verified: `yarn install --immutable`, `yarn build`, and `yarn test` (181 tests) all pass.

_PR description authored by Claude on Domas's behalf._