### PR TITLE
fix(ci): only run the NPM publish job on actual releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -96,7 +96,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: ${{ needs.release-please.outputs.releases_created }}
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
 
     env:
       NPM_CONFIG_ACCESS: public


### PR DESCRIPTION
`release-please-action` emits `releases_created` as the string `'false'` (not empty) when no release is cut, and GitHub treats any non-empty string in an `if` as truthy — so the Publish job triggered on every push to `main` and parked in `waiting` on the npm environment gate (only that gate + `from-package` idempotency prevented stray publishes).

Compare against the literal `'true'` so the job runs only when a release PR merges.

_PR description authored by Claude on Domas's behalf._