### PR TITLE
fix(ci): refresh release PR lockfile on updates, not just creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -40,9 +40,15 @@ jobs:
       # resolution would change — additionally, Yarn berry auto-enables
       # hardened mode on public PR workflows, which forbids any lockfile
       # mutation. Refresh yarn.lock on the release branch so CI passes.
+      #
+      # Gate on the `pr` output (present whenever a release PR was created OR
+      # updated), not `prs_created` (only true on first creation). Subsequent
+      # commits to main update the existing release PR with new version bumps
+      # but leave `prs_created` false, so gating on it would skip the refresh
+      # and let yarn.lock drift out of sync until --immutable fails.
       - name: Resolve release PR branch
         id: release-branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.pr != '' && steps.release.outputs.pr != 'null' }}
         env:
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
@@ -50,7 +56,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Checkout release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        if: ${{ steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
         with:
           ref: ${{ steps.release-branch.outputs.branch }}
@@ -58,18 +64,18 @@ jobs:
           persist-credentials: true
 
       - name: Enable corepack
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        if: ${{ steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
         run: corepack enable
 
       - name: Setup Node.js
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        if: ${{ steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
         with:
           node-version-file: .nvmrc
           package-manager-cache: false
 
       - name: Refresh yarn.lock on release PR
-        if: ${{ steps.release.outputs.prs_created == 'true' && steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        if: ${{ steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
         run: |
           set -euo pipefail
           # `--mode update-lockfile` writes the lockfile without installing


### PR DESCRIPTION
## What

Gate the release-please \"Refresh yarn.lock on release PR\" steps on the action's `pr` output instead of `prs_created`.

## Why

release-please rewrites cross-package version ranges in each `package.json` (e.g. `@grafana/faro-cli` `^0.10.0` → `^0.11.0`) but does not touch `yarn.lock`. The `run-tests` workflow runs `yarn install --immutable`, which then aborts with `YN0028: The lockfile would have been modified` before any test runs.

The workflow already has a step to refresh the lockfile on the release branch, but it was gated on `steps.release.outputs.prs_created == 'true'`. That output is only `true` when release-please **creates a new** release PR. Every subsequent commit to `main` **updates** the existing release PR (new version bumps) with `prs_created == false`, so the refresh step was **skipped** on every update — letting `yarn.lock` drift out of sync until `--immutable` failed.

This was observed on the open `chore: release main` PR (#613): the refresh step was confirmed `skipped` in recent release-please runs, and the branch's `yarn.lock` still recorded `^0.10.0` ranges while the manifests declared `^0.11.0`.

## Change

- Resolve-branch step now gates on `steps.release.outputs.pr` being present (non-empty / non-`null`) — populated whether the release PR was created or updated.
- The four downstream steps drop the `prs_created` term and rely on the existing `release-branch.outputs.branch` guard, which is only set when `pr` was present (so it carries the same condition transitively).
- Added a comment documenting the gating rationale to prevent regression.

## Note

This takes effect on future release-please runs. The currently-open release PR still needs its lockfile refreshed once (either a manual `yarn install --mode update-lockfile` push, or the next release-please run after this merges).

## Test plan

- [x] YAML parses (`yq`), 7 steps in the `release-please` job
- [x] No `prs_created` references remain in any step condition
- [ ] Verify on next release-please run that the refresh step executes on a PR **update** (not just creation)