### PR TITLE
chore(ci): commit release PR lockfile via signed API commit

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,6 +76,9 @@ jobs:
 
       - name: Refresh yarn.lock on release PR
         if: ${{ steps.release-branch.outputs.branch != '' && steps.release-branch.outputs.branch != 'null' }}
+        env:
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          BRANCH: ${{ steps.release-branch.outputs.branch }}
         run: |
           set -euo pipefail
           # `--mode update-lockfile` writes the lockfile without installing
@@ -86,13 +89,24 @@ jobs:
             echo "yarn.lock already in sync."
             exit 0
           fi
-          # Match the identity the release-please-action uses for its commits
-          # on the same branch, so this commit appears as the same bot.
-          git config user.name 'app-o11y-kwl-ci[bot]'
-          git config user.email 'app-o11y-kwl-ci[bot]@users.noreply.github.com'
-          git add yarn.lock
-          git commit -m 'chore: refresh yarn.lock for release PR'
-          git push
+          # Commit via the GitHub Contents API rather than `git push`. The
+          # release branch is covered by a `required_signatures` ruleset, so a
+          # plain push of a locally-created (unsigned) commit is rejected with
+          # "push declined due to repository rule violations". Commits created
+          # through the API are signed by GitHub automatically — the same
+          # mechanism release-please-action's own commits rely on — so they
+          # satisfy the ruleset.
+          base64 -w0 yarn.lock > "${RUNNER_TEMP}/yarn-lock.b64"
+          SHA="$(gh api "repos/${GITHUB_REPOSITORY}/contents/yarn.lock?ref=${BRANCH}" --jq '.sha')"
+          jq -nc \
+            --arg message 'chore: refresh yarn.lock for release PR' \
+            --arg branch "$BRANCH" \
+            --arg sha "$SHA" \
+            --rawfile content "${RUNNER_TEMP}/yarn-lock.b64" \
+            '{message: $message, branch: $branch, sha: $sha, content: $content}' \
+            > "${RUNNER_TEMP}/contents-body.json"
+          gh api "repos/${GITHUB_REPOSITORY}/contents/yarn.lock" \
+            -X PUT --input "${RUNNER_TEMP}/contents-body.json"
 
   publish:
     name: Publish to NPM


### PR DESCRIPTION
## What

The "Refresh yarn.lock on release PR" step now commits the regenerated lockfile through the GitHub Contents API instead of `git commit` + `git push`.

## Why

After the gating fix (#628), the refresh step runs on release-PR updates for the first time and immediately fails at the push:

```
! [remote rejected] release-please--branches--main (push declined due to repository rule violations)
```

A repo-wide "Signed Commits" ruleset (`required_signatures`, targeting all branches) was added recently and has no bypass actors. A locally-created commit pushed over HTTPS is unsigned, so the ruleset rejects it. release-please-action's own commits land fine because it creates them through the GitHub API, which GitHub signs automatically.

Routing our lockfile commit through the Contents API (`PUT .../contents/yarn.lock`) produces a GitHub-signed, verified commit that satisfies the ruleset — the same mechanism release-please already relies on. No bypass actor or settings change required, so the signing guarantee stays intact everywhere.

The base64 payload is written to `RUNNER_TEMP` and sent via `gh api --input` to avoid command-line argument length limits on the lockfile.

## Effect on the open release PR

Once this merges, the merge to `main` triggers release-please, which updates the existing release PR with a signed lockfile commit and lets its CI pass — no manual lockfile sync or PR re-creation needed.