### PR TITLE
chore: rename Gradle plugin id to com.grafana.faro.android-symbols

### DIFF
--- a/packages/faro-cli/src/cli.ts
+++ b/packages/faro-cli/src/cli.ts
@@ -357,7 +357,7 @@ metro
   .option('-k, --api-key <key>', 'Bearer API key (env: FARO_SOURCEMAP_API_KEY)')
   .option(
     '-b, --bundle-id <id>',
-    'Bundle id matching the shipped JS bundle (env: FARO_BUNDLE_ID). On Android React Native with com.grafana.faro, omit — Gradle supplies applicationId@versionCode@versionName via @grafana/faro-metro-plugin.',
+    'Bundle id matching the shipped JS bundle (env: FARO_BUNDLE_ID). On Android React Native with com.grafana.faro.android-symbols, omit — Gradle supplies applicationId@versionCode@versionName via @grafana/faro-metro-plugin.',
   )
   .option('--no-gzip', 'POST the raw .map JSON instead of a gzipped tarball')
   .option('-v, --verbose', 'Verbose logging', false)

--- a/packages/faro-metro-plugin/src/resolveBundleId.ts
+++ b/packages/faro-metro-plugin/src/resolveBundleId.ts
@@ -155,7 +155,7 @@ function resolveFromAndroidGradle(
   if (!id || !validateAndroidBundleId(id)) {
     throw new Error(
       `[faro-metro-plugin] Invalid or missing bundle id at ${filePath}. ` +
-        'Apply the Faro Gradle plugin (com.grafana.faro) and ensure release variant version fields are set.'
+        'Apply the Faro Gradle plugin (com.grafana.faro.android-symbols) and ensure release variant version fields are set.'
     );
   }
   return normalizeBundleIdLength(id);


### PR DESCRIPTION
## Summary

Update `faro-metro-plugin` and `faro-cli` references to the renamed Gradle plugin id `com.grafana.faro.android-symbols`.

Metro still invokes `faroWriteBundleIdRelease` and reads `app/build/faro/bundle-id-release.txt`; only the documented plugin id in error messages and CLI help text changes.

Made with [Cursor](https://cursor.com)