### PR TITLE
fix(deps): raise undici floor to ^8.5.0

### DIFF
--- a/packages/faro-bundlers-shared/package.json
+++ b/packages/faro-bundlers-shared/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "ansis": "^4.0.0",
     "tar": "^7.1.0",
-    "undici": "^8.1.0"
+    "undici": "^8.5.0"
   },
   "files": [
     "dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1767,7 +1767,7 @@ __metadata:
     "@types/tar": "npm:7.0.87"
     ansis: "npm:^4.0.0"
     tar: "npm:^7.1.0"
-    undici: "npm:^8.1.0"
+    undici: "npm:^8.5.0"
     undici-types: "npm:8.5.0"
   languageName: unknown
   linkType: soft
@@ -10515,10 +10515,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^8.1.0":
-  version: 8.5.0
-  resolution: "undici@npm:8.5.0"
-  checksum: 10/e95913777afd47d76babfe62547bb4e9a94b93f44b50c84b4e0b6fa41c00364e31ff4f433a955b1592c3162f43e8757e2e0feae6eea195187730594523393568
+"undici@npm:^8.5.0":
+  version: 8.7.0
+  resolution: "undici@npm:8.7.0"
+  checksum: 10/e9644903bda97f825228b4c7bee95b3586609f94df685b598c32bdaf3ac795928cbd25b0ed2690c3ea0b5abd324f5a9641b63b6c81c9b19f3ef4d5b3e402a48c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
Raises the `undici` range in `@grafana/faro-bundlers-shared` from `^8.1.0` to `^8.5.0` so consumers cannot resolve versions affected by CVE-2026-12151 (HIGH, CVSS 7.5) — a WebSocket client DoS via unbounded continuation frames. Resolves to 8.7.0 in the lockfile; `yarn build` (build + typecheck) passes.

Dependabot alert: https://github.com/grafana/faro-javascript-bundler-plugins/security/dependabot/149