### PR TITLE
fix(deps): bump tar, fast-uri, js-yaml, tmp and brace-expansion

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,16 @@
   },
   "resolutions": {
     "axios": "1.18.1",
-    "fast-uri": "4.0.0",
+    "fast-uri": "4.1.1",
     "form-data": "4.0.6",
-    "tar": "7.5.17",
-    "js-yaml": "5.2.0"
+    "tar": "7.5.21",
+    "js-yaml": "5.2.2",
+    "tmp": "^0.2.7",
+    "brace-expansion@npm:^1.1.7": "^1.1.16",
+    "brace-expansion@npm:1.1.15": "1.1.16",
+    "brace-expansion@npm:^2.0.2": "^2.1.2",
+    "brace-expansion@npm:2.1.1": "2.1.2",
+    "brace-expansion@npm:^5.0.5": "^5.0.8",
+    "brace-expansion@npm:5.0.6": "5.0.8"
   }
 }

--- a/packages/faro-bundlers-shared/package.json
+++ b/packages/faro-bundlers-shared/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "ansis": "^4.0.0",
-    "tar": "^7.1.0",
+    "tar": "^7.5.21",
     "undici": "^8.5.0"
   },
   "files": [

--- a/packages/faro-cli/package.json
+++ b/packages/faro-cli/package.json
@@ -23,7 +23,7 @@
     "commander": "^15.0.0",
     "dotenv": "^17.0.1",
     "glob": "^13.0.0",
-    "tar": "^7.1.0"
+    "tar": "^7.5.21"
   },
   "devDependencies": {
     "@jest/globals": "30.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1766,7 +1766,7 @@ __metadata:
     "@rollup/plugin-typescript": "npm:12.3.0"
     "@types/tar": "npm:7.0.87"
     ansis: "npm:^4.0.0"
-    tar: "npm:^7.1.0"
+    tar: "npm:^7.5.21"
     undici: "npm:^8.5.0"
     undici-types: "npm:8.5.0"
   languageName: unknown
@@ -1787,7 +1787,7 @@ __metadata:
     dotenv: "npm:^17.0.1"
     glob: "npm:^13.0.0"
     jest: "npm:30.4.2"
-    tar: "npm:^7.1.0"
+    tar: "npm:^7.5.21"
     ts-jest: "npm:29.4.11"
   bin:
     faro-cli: dist/cjs/cli.js
@@ -4428,31 +4428,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.6, brace-expansion@npm:^5.0.5":
-  version: 5.0.6
-  resolution: "brace-expansion@npm:5.0.6"
+"brace-expansion@npm:5.0.8, brace-expansion@npm:^5.0.8":
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
+  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+"brace-expansion@npm:^1.1.16":
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/f2a950034e670523cc186da61aabe3beab74b1b8a7c74a756bf6b172dad1917312f255d9ec46906c9f0cab530868095d8c143918576930dd0e1323c3803850f1
+  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+"brace-expansion@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10/4681c533dc4e6c77b3ad795b38683d297fd03c739a17bfb2a338529fa7dcf4540683a79dcd662905f4c5b0db7cfda18daafcd18dd1bbf7c3b076fe0c9c3487eb
+  checksum: 10/0e0f9b0df1f0809e9c326470e022eeb24334ddb54c43b1ac39f1d38f3cbaeb940794de1db826f5491843ac00d7932c43f10350a65ccd51fe7d05da627152f204
   languageName: node
   linkType: hard
 
@@ -5684,10 +5684,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:4.0.0":
-  version: 4.0.0
-  resolution: "fast-uri@npm:4.0.0"
-  checksum: 10/c44eabda24216f34eb83b97c5a30f37df1b18467b39c46873e4a54ae80e7fdf795b45891dbe5e896f4d21fd6509fa4b309135dd473a62127b2cdb93189a62204
+"fast-uri@npm:4.1.1":
+  version: 4.1.1
+  resolution: "fast-uri@npm:4.1.1"
+  checksum: 10/f8a186718e360ffb0888b812892dc2930902c4200b9a35ab15923678b4cbcece04a155d36edc74f1ed3e5a9f60893095cf195b6e0a2351282f7714bac0993445
   languageName: node
   linkType: hard
 
@@ -7254,14 +7254,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:5.2.0":
-  version: 5.2.0
-  resolution: "js-yaml@npm:5.2.0"
+"js-yaml@npm:5.2.2":
+  version: 5.2.2
+  resolution: "js-yaml@npm:5.2.2"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.mjs
-  checksum: 10/8a5e55c5d0fcafae4ac02114a99dc070048b8e5a82a056089ce1f69f8a00fd8eb05b622e76ad50aac1f9d409010636c9616c6b2ed4e58dae138379a60d301220
+  checksum: 10/2b4c2933af12c97e1c4894a4f27fe9b06dab70a64a96bb50624b4429bef6bf11008bde20d868bce52a36784473314efc30078ba6025b58cf7537961e23b1ae9c
   languageName: node
   linkType: hard
 
@@ -10178,16 +10178,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:7.5.17":
-  version: 7.5.17
-  resolution: "tar@npm:7.5.17"
+"tar@npm:7.5.21":
+  version: 7.5.21
+  resolution: "tar@npm:7.5.21"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10/89c289e29c5e81d7a166daf0856f6a9f6e28abb9d1053d047b227be2ce2eeee776664d20a62be53efdcabd6cb373517f12b9a960f23116fc13cbc490261b2d7e
+  checksum: 10/a1b7dcee15e4f7dbef7f07c3cf0fe946248efabd1cb029b54c698d817dfc2876c75bcaa164a12dd21191e385759ce3e37fea562cf4aabaa00984ef9ed3c48d17
   languageName: node
   linkType: hard
 
@@ -10267,10 +10267,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tmp@npm:0.2.6":
-  version: 0.2.6
-  resolution: "tmp@npm:0.2.6"
-  checksum: 10/4ba072821d65f6ec0ae680dd49261bcc66c96a5a463c80ca040747256238aaad68ad5db7aa8367dd1554d22aa77c2988bdb1c5556ecfc4df105f5b73206b7d9b
+"tmp@npm:^0.2.7":
+  version: 0.2.7
+  resolution: "tmp@npm:0.2.7"
+  checksum: 10/0a3bc90beb0c6275273c3475fb57e466eaab1c9c4a101d029ff62b18146ce136e7f75d09de34863d9f2c2a492751402508f9e028bc98eb34a1416195d4b15619
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes the CVEs that `yarn npm audit` reports on main, including a critical one in tar (GHSA-23hp-3jrh-7fpw).

The `resolutions` block was pinning tar, fast-uri and js-yaml at exactly the vulnerable versions, so bumping deps alone would not have moved them. Raised those pins, and also raised the declared tar floor in faro-bundlers-shared and faro-cli so consumers get the patched range too. Resolutions only bind our own install.

tar is on 7.5.21 rather than 7.5.22 because the registry proxy still has 7.5.22 quarantined. 7.5.21 clears all four tar advisories.

Before: 1 critical, 9 high, 3 moderate
After: 1 high

What is left is brace-expansion 1.x and 2.x. The OOM fix only landed in 5.0.8 and forcing 5.x onto minimatch 3 and 9 breaks them, the export shape changed. Those paths are jest and lerna only.

Note: the rollup and webpack plugin tests already fail on a clean main, both TypeScript errors unrelated to deps. I checked the baseline before and after. Everything else passes, 144 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)