### PR TITLE
fix(deps): repair brace-expansion resolutions and restore a valid lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,9 @@
     "tar": "7.5.22",
     "js-yaml": "5.2.3",
     "tmp": "^0.2.7",
-    "brace-expansion@npm:^1.1.7": "^1.1.16",
-    "brace-expansion@npm:1.1.15": "1.1.16",
-    "brace-expansion@npm:^2.0.2": "^2.1.2",
-    "brace-expansion@npm:2.1.1": "2.1.4",
-    "brace-expansion@npm:^5.0.5": "^5.0.8",
-    "brace-expansion@npm:5.0.6": "5.0.9"
+    "brace-expansion@npm:^1.1.7": "1.1.18",
+    "brace-expansion@npm:^2.0.2": "2.1.4",
+    "brace-expansion@npm:^5.0.5": "5.0.9",
+    "brace-expansion@npm:5.0.8": "5.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4430,40 +4430,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+    concat-map: "npm:0.0.1"
+  checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:2.1.4":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
+  dependencies:
+    balanced-match: "npm:^1.0.0"
+  checksum: 10/11e18dc39706037331abedbb742af1da733267042f94c0f08487ef1a63cee068c1859f8d5f95523869725191133eb1a69753de457ed4b76b7c187d9ea0646737
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:5.0.9":
   version: 5.0.9
   resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
   checksum: 10/d8683d612919212c7cf298861acd1c15101e7e2ad186e7ae9747390e5b3fc9e9b55ce71107570d32985784d9d88fbbe438d725863aed7b0f3d08d5f080535eec
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
-  dependencies:
-    balanced-match: "npm:^1.0.0"
-  checksum: 10/0e0f9b0df1f0809e9c326470e022eeb24334ddb54c43b1ac39f1d38f3cbaeb940794de1db826f5491843ac00d7932c43f10350a65ccd51fe7d05da627152f204
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Why this is urgent

`yarn install --immutable` currently fails on `main`. Every pull request opened against `main` fails at the install step, and the vulnerable version of `brace-expansion` is still the one that gets installed. This PR fixes both.

To reproduce on `main`:

```
corepack enable && yarn install --immutable
# YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

## Root cause

Three of the six `brace-expansion` resolution keys did not match any descriptor that packages in this tree actually request. Only four descriptors exist:

| Descriptor | Requested by | Covered by a resolution key? |
|---|---|---|
| `npm:^1.1.7` (x2) | `minimatch@3.1.4`, `minimatch@3.1.5` | yes |
| `npm:^2.0.2` | `minimatch@9.0.9` | yes |
| `npm:^5.0.5` | `minimatch@10.2.5` | yes |
| `npm:5.0.8` | `nx@23.1.1` | **no** |

The keys `1.1.15`, `2.1.1` and `5.0.6` matched none of those, so bumping their values had no effect on what gets installed. The `npm:5.0.8` descriptor requested by `nx` had no resolution covering it at all.

Separately, #654 renamed the lockfile key `"brace-expansion@npm:5.0.8, brace-expansion@npm:^5.0.8"` to `"brace-expansion@npm:5.0.9"`. No resolution backed that rename, so `nx`'s `npm:5.0.8` dependency was left without a matching lockfile entry. That is the immediate cause of the failing install. Yarn's own resolution reverts the rename and selects 5.0.8 again, so the advisory was never actually closed.

## What changed

Six resolution keys become four, each keyed on a descriptor that really exists, and each pinned to the patched version from [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895):

```json
"brace-expansion@npm:^1.1.7": "1.1.18",
"brace-expansion@npm:^2.0.2": "2.1.4",
"brace-expansion@npm:^5.0.5": "5.0.9",
"brace-expansion@npm:5.0.8":  "5.0.9"
```

Exact versions replace the previous caret ranges. A caret range lets the lockfile keep an older patch level that still satisfies it, which is how 1.1.16, 2.1.2 and 5.0.8 survived several rounds of updates.

Note that the v1 line is patched at 1.1.18, so no major version bump is needed on any line.

## Verification

Run locally with Yarn 4.18.0:

- `yarn install --immutable` passes
- `yarn build` passes, including `tsc --noEmit` across all six packages
- `yarn test` passes, 6/6 projects
- `yarn.lock` now has exactly three `brace-expansion` entries: `1.1.18`, `2.1.4`, `5.0.9`, with no stale duplicates

## Follow-ups

- Closes the work attempted in #651, which proposed an unnecessary major bump to v2 and had no lockfile because Renovate's artifact runner used global Yarn 1.22.22 against `packageManager: yarn@4.18.0`. That PR can be closed.
- #655 is a stale duplicate of the already merged #654 and can be closed.
- The Renovate behaviour that mutated the resolution keys, and the Corepack failure in its artifact runner, both need reporting so this does not recur.