### PR TITLE
chore: keep pre-1.0 versioning for breaking changes

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -32,6 +32,7 @@
       "release-type": "node"
     }
   },
+  "bump-minor-pre-major": true,
   "include-v-in-tag": true,
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
 }


### PR DESCRIPTION
Set `bump-minor-pre-major` so breaking changes bump the minor version while packages are below 1.0.0, instead of jumping straight to 1.0.0.

All six packages are on 0.x. With this option unset, release-please defaults it to false, so the next commit carrying `feat!` or a `BREAKING CHANGE:` footer would release every package as 1.0.0 — a statement that the API is stable, made as a side effect rather than a decision.

Consumers are protected either way: npm's caret pins the minor below 1.0.0, so `^0.11.1` resolves to `>=0.11.1 <0.12.0` and does not pick up a 0.12.0 that contains breaking changes.

Reverting this is how we opt in to 1.0.0 when we actually mean it.