### PR TITLE
fix(security): update brace-expansion to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,12 @@
     "tar": "7.5.22",
     "js-yaml": "5.2.3",
     "tmp": "^0.2.7",
-    "brace-expansion@npm:^1.1.7": "^1.1.16",
-    "brace-expansion@npm:1.1.15": "1.1.16",
-    "brace-expansion@npm:^2.0.2": "^2.1.2",
+    "brace-expansion@npm:^1.1.7": "^1.1.18",
+    "brace-expansion@npm:1.1.15": "1.1.18",
+    "brace-expansion@npm:^2.0.2": "^2.1.4",
     "brace-expansion@npm:2.1.1": "2.1.4",
-    "brace-expansion@npm:^5.0.5": "^5.0.8",
-    "brace-expansion@npm:5.0.6": "5.0.9"
+    "brace-expansion@npm:^5.0.5": "^5.0.9",
+    "brace-expansion@npm:5.0.6": "5.0.9",
+    "brace-expansion@npm:5.0.8": "5.0.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4430,7 +4430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:5.0.9":
+"brace-expansion@npm:5.0.9, brace-expansion@npm:^5.0.9":
   version: 5.0.9
   resolution: "brace-expansion@npm:5.0.9"
   dependencies:
@@ -4439,31 +4439,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^1.1.16":
-  version: 1.1.16
-  resolution: "brace-expansion@npm:1.1.16"
+"brace-expansion@npm:^1.1.18":
+  version: 1.1.18
+  resolution: "brace-expansion@npm:1.1.18"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10/94498bead66c51536df5b7bf1b0a0e581a5b7f86888be10481d06920c4bd9d976e003b13a3d19fddc733f21a09d162ff72f90e18b2c9d062b15121e973d0e13b
+  checksum: 10/b55a3c03239b8d2127c7cbb3408c9ad3a556a8c303bf3064df78bfb7c093160fc8f6e0a32e42a850a78eba12f29ccf6ef997690b9acf945d242c56c61c4aa977
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "brace-expansion@npm:2.1.2"
+"brace-expansion@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "brace-expansion@npm:2.1.4"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10/0e0f9b0df1f0809e9c326470e022eeb24334ddb54c43b1ac39f1d38f3cbaeb940794de1db826f5491843ac00d7932c43f10350a65ccd51fe7d05da627152f204
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
+  checksum: 10/11e18dc39706037331abedbb742af1da733267042f94c0f08487ef1a63cee068c1859f8d5f95523869725191133eb1a69753de457ed4b76b7c187d9ea0646737
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
GHSA-rgw5-rvv9-x895 (high, DoS via unbounded intermediate arrays) is patched in 1.1.18, 2.1.4 and 5.0.9. The existing resolutions targeted 1.1.16, 2.1.2 and 5.0.8, all of which are in the vulnerable range, so the tree installed vulnerable versions on every branch. The only patched entry in the lockfile was `brace-expansion@npm:5.0.9`, which was orphaned — nothing resolved to it.

That orphaned entry also broke CI. A fresh resolve does not produce it, so `yarn install --immutable` wanted to rewrite the lockfile and failed with YN0028 on every pull request. `run-tests` only triggers on `pull_request`, so main was never checked and the drift went unnoticed.

Adds a resolution for the exact `5.0.8` descriptor, which no range resolution covered.

After this change the tree resolves to 1.1.18, 2.1.4 and 5.0.9, and `yarn install --immutable` succeeds.