### PR TITLE
fix(security): update ip-address to patched version

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6594,9 +6594,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.1.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10/12fec399e1af5753ac322e47a6d81a50d3a528b3abb17c09525b2a2edcaedcca628c40520706f7037bc4d8e951b0296c47e7b86d0a8e6e2335c8f0ba4afcfac1
+  version: 10.5.0
+  resolution: "ip-address@npm:10.5.0"
+  checksum: 10/239645a11ae56f1f8721df22fa852dec51039a0add5371a474ad858810a6b6a4924c9346e467821c4e614bc9b8c8947a58ba1fdfb155a7a30437a440072ffbf5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Addresses **CVE-2026-69192** ([GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr)).

`ip-address` <= 10.3.0 decodes IPv4 octets with leading zeros as decimal, while the WHATWG URL parser, `inet_aton` and `getaddrinfo` treat them as octal. So `012.0.0.1` is classified by `Address4` as the public `12.0.0.1` but actually resolves to the private `10.0.0.1` — any SSRF allow/deny check built on the library can be bypassed. Patched in 10.3.1.

| Package | From | To | CVE | Strategy |
| --- | --- | --- | --- | --- |
| `ip-address` | 10.2.0 | 10.5.0 | CVE-2026-69192 | natural re-resolution (lockfile only) |

### Why lockfile-only

`ip-address` is a transitive **dev-only** dependency:

```
lerna (root devDependency)
  └─ @npmcli/agent@^4.0.0
       └─ socks-proxy-agent@^8.0.3
            └─ socks@^2.8.3
                 └─ ip-address@^10.1.1   → was 10.2.0, now 10.5.0
```

No published package (`@grafana/faro-bundlers-shared`, `-cli`, `-esbuild`, `-metro-plugin`, `-rollup`, `-webpack`) depends on `socks` or `ip-address`, so nothing vulnerable shipped to consumers — this only affects the local build toolchain.

The single lockfile descriptor is `ip-address@npm:^10.1.1`, a range that already covers the patched 10.3.1. The vulnerable 10.2.0 was simply frozen from an earlier install, not pinned by anything, so `yarn up ip-address -R` reached the fix without a `resolutions` entry. That's the difference from the `brace-expansion` / `axios` / `tar` entries in `package.json`, where the declared ranges did *not* reach the fixed version and an override was the only option. Adding a resolution here would be a redundant pin to maintain.

Yarn always resolves to the highest in-range version, so a later `yarn install` or lock-file-maintenance run can't regress this to 10.2.0.

### Test plan

- [x] `yarn install --immutable` passes (CI parity with `.github/workflows/run-tests.yml`)
- [x] Build, typecheck, and `yarn smoke:packages` pass for all 6 packages
- [x] Tests pass — 181 tests, 14 suites, 0 failures
- [x] `git diff --stat` touches `yarn.lock` only

### Note for reviewers

Renovate PR #633 (lock file maintenance) is still open and may incidentally touch the same stanza — worth deciding which lands first.